### PR TITLE
suggests data.table, uses eval-substitute rather than eval-parse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Description: Provides functions loosely based on STATA's collapse
     function to perform advanced data aggregation and summary statistics for
     multi-type datasets and multi-level (panel) data. 
 License: GPL (>=2)
+Suggests: data.table
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1

--- a/R/collap.R
+++ b/R/collap.R
@@ -166,8 +166,7 @@ collap <- function(X, by = NULL, FUN = mean, catFUN = Mode, factors = "as.catego
           old = parse(text = paste0("df_old = data.table::setDT(df)[, lapply(.SD, ",nam,ifelse(missing(...),"",paste0(", ",deparse(substitute(...)))),"), keyby = by]"))
         }
         new = substitute(df <- data.table::setDT(df)[, .lapplyCall, keyby = by],
-                         list(.nam=as.name(nam), .dots=ifelse(missing(...), substitute(), substitute(...)),
-                              .lapplyCall = as.call(c(
+                         list(.lapplyCall = as.call(c(
                                 list(as.name("lapply"), as.name(".SD"), as.name(nam)),
                                 if (narmcalls) list(na.rm = TRUE) else list(), # here we handle narmcalls or nonarmcalls
                                 if (missing(...)) list() else as.list(substitute(...)) # here we handle dots

--- a/R/helperfunctions.R
+++ b/R/helperfunctions.R
@@ -17,3 +17,5 @@ Mode <- function(x, na.rm = FALSE) {
   attributes(y) <- ax
   return(y)
 }
+
+.datatable.aware = TRUE

--- a/man/collap.Rd
+++ b/man/collap.Rd
@@ -45,7 +45,7 @@ collap(X, by = NULL, FUN = mean, catFUN = Mode,
 
 \item{show.statistic}{If multiple functions are called and reshape.long = TRUE, show.statistic = FALSE can be called to omit the 'Statistic' column and instead make appropriate row.names.}
 
-\item{data.table}{By default \emph{collap} is built as a wrapper around \emph{aggregate.data.frame}. Calling this argument will internally use \emph{data.table} as workhorse function, yielding significant speed improvements for large datasets.}
+\item{data.table}{By default \emph{collap} is built as a wrapper around \emph{aggregate.data.frame}. Calling this argument will internally use \emph{data.table} as workhorse function, yielding significant speed improvements for large datasets. Requires \code{data.table} package to be installed.}
 
 \item{parallel}{If multiple functions are supplied to 'FUN' or 'catFUN', parallel = TRUE will automatically parallelize computation on $k-1$ of the available cores (using the \emph{parLapply} function from the \emph{parallel} package). The argument works together with data.table = TRUE to guarantee maximum performance on tasks involving large datsets and multiple functions.}
 


### PR DESCRIPTION
- avoids call to `library` inside package code by defining suggested (fully optional) dependency on data.table package.
- rather than using `eval`+`parse` there is now `eval`+`substitute` code as a supplement, once tests will be added and will be passing, the old `eval`+`parse` could be removed. Reasons behind change of `eval`+`parse` to `eval`+`substitute` can be found in [StackOverflow question "How can one work fully generically in data.table in R with column names in variables"](https://stackoverflow.com/a/54800108/2490497).
- appears to partially address #1