### PR TITLE
Define STRICT_R_HEADERS and include cfloat in two files

### DIFF
--- a/src/fmode.cpp
+++ b/src/fmode.cpp
@@ -1,4 +1,6 @@
 // [[Rcpp::plugins(cpp11)]]
+#define STRICT_R_HEADERS
+#include <cfloat>
 #include <Rcpp.h>
 using namespace Rcpp ;
 

--- a/src/fnth_fmedian.cpp
+++ b/src/fnth_fmedian.cpp
@@ -1,5 +1,7 @@
 // [[Rcpp::plugins(cpp11)]]
 #include <numeric>
+#define STRICT_R_HEADERS
+#include <cfloat>
 #include <Rcpp.h>
 using namespace Rcpp;
 


### PR DESCRIPTION
Hi Sebastian,

Your CRAN package collapse uses Rcpp, and is affected if we add the definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

Here, I prefixed two #include <Rcpp.h> with STRICT_R_HEADERS. One additional change that is needed is the #include <cfloat> (or <float.h> if you prefer C style) , that is equivalent). We now can use DBL_MIN.  One could (and I would) add STRICT_R_HEADERS to all files with #include Rcpp.h, but I left that to him---not everybody likes more invavise PRs.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
  https://github.com/RcppCore/Rcpp/issues/1158
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.