### PR TITLE
Ensuring that index variables are always kept in operator methods if …

### DIFF
--- a/R/fbetween_fwithin.R
+++ b/R/fbetween_fwithin.R
@@ -122,7 +122,7 @@ W.pdata.frame <- function(x, effect = 1L, w = NULL, cols = is.numeric, na.rm = T
   g <- group_effect(x, effect)
 
   if(keep.ids) {
-    gn <- which(nam %in% attr(findex(x), "names"))
+    gn <- which(nam %in% attr(findex(x), "nam")) # Needed for 3+ index variables
     if(length(gn) && is.null(cols)) cols <- seq_along(x)[-gn]
   } else gn <- NULL
 
@@ -323,7 +323,7 @@ B.pdata.frame <- function(x, effect = 1L, w = NULL, cols = is.numeric, na.rm = T
   g <- group_effect(x, effect)
 
   if(keep.ids) {
-    gn <- which(nam %in% attr(findex(x), "names"))
+    gn <- which(nam %in% attr(findex(x), "nam")) # Needed for 3+ index variables
     if(length(gn) && is.null(cols)) cols <- seq_along(x)[-gn]
   } else gn <- NULL
 

--- a/R/fdiff_fgrowth.R
+++ b/R/fdiff_fgrowth.R
@@ -229,7 +229,7 @@ DG_pdata_frame_template <- function(x, n = 1, diff = 1, cols = is.numeric, fill 
   index <- uncl2pix(x)
 
   if(keep.ids) {
-    gn <- which(nam %in% names(index))
+    gn <- which(nam %in% attr(index, "nam")) # Needed for 1 or 3+ index variables
     if(length(gn) && is.null(cols)) cols <- seq_along(unclass(x))[-gn]
   } else gn <- NULL
 

--- a/R/flag.R
+++ b/R/flag.R
@@ -146,7 +146,7 @@ L.pdata.frame <- function(x, n = 1, cols = is.numeric, fill = NA, stubs = TRUE, 
   index <- uncl2pix(x)
 
   if(keep.ids) {
-    gn <- which(nam %in% names(index))
+    gn <- which(nam %in% attr(index, "nam")) # Needed for 1 or 3+ index variables
     if(length(gn) && is.null(cols)) cols <- seq_along(unclass(x))[-gn]
   } else gn <- NULL
 

--- a/R/fscale.R
+++ b/R/fscale.R
@@ -125,7 +125,7 @@ STD.pdata.frame <- function(x, effect = 1L, w = NULL, cols = is.numeric,
   g <- group_effect(x, effect)
 
   if(keep.ids) {
-    gn <- which(nam %in% attr(findex(x), "names"))
+    gn <- which(nam %in% attr(findex(x), "nam")) # Needed for 3+ index variables
     if(length(gn) && is.null(cols)) cols <- seq_along(x)[-gn]
   } else gn <- NULL
 

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -238,8 +238,11 @@ findex_by <- function(.X, ..., single = "auto", interact.ids = TRUE) { # pid = N
   } else {
     lids <- length(ids)
     if(lids > 2L) {
-      if(interact.ids) ids <- c(`names<-`(list(finteraction(ids[-lids], sort = FALSE)), paste(names(ids)[-lids], collapse = ".")), ids[lids])
-      else ids[-lids] <- lapply(ids[-lids], function(x) qF(x, sort = is.factor(x), na.exclude = FALSE))
+      if(interact.ids) {
+        nam <- names(ids)
+        ids <- c(`names<-`(list(finteraction(ids[-lids], sort = FALSE)), paste(nam[-lids], collapse = ".")), ids[lids])
+        attr(ids, "nam") <- nam # This is a trick, fetched using attr(x, "nam"), before "names" attribute
+      } else ids[-lids] <- lapply(ids[-lids], function(x) qF(x, sort = is.factor(x), na.exclude = FALSE))
     } else ids[[1L]] <- qF(ids[[1L]], sort = is.factor(ids[[1L]]), na.exclude = FALSE)
     ids[[length(ids)]] <- make_time_factor(ids[[length(ids)]])
   }
@@ -269,17 +272,19 @@ group_effect <- function(x, effect) {
 uncl2pix <- function(x, interact = FALSE) {
   ix <- unclass(findex(x))
   if(length(ix) == 2L) return(ix)
-  if(length(ix) == 1L) return(if(isTRUE(attr(ix, "single.id"))) list(ix[[1L]], NULL) else list(0L, ix[[1L]]))
-  if(length(ix) > 2L) {
+  if(length(ix) == 1L) {
+    res <- if(isTRUE(attr(ix, "single.id"))) list(ix[[1L]], NULL) else list(0L, ix[[1L]])
+  } else if(length(ix) > 2L) {
     if(interact) {
       g <- finteraction(ix[-length(ix)])
     } else {
       g <- group(ix[-length(ix)])
       attr(g, "levels") <- seq_len(attr(g, "N.groups"))
     }
-    return(list(g, ix[[length(ix)]]))
-  }
-  stop("invalid 'index' length")
+    res <- list(g, ix[[length(ix)]])
+  } else stop("invalid 'index' length")
+  attr(res, "nam") <- names(ix)
+  return(res)
 }
 
 plm_check_time <- function(x) {

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -84,3 +84,22 @@ test_that("descriptives work well", {
   expect_equal(qtable(r = wlddev$region, i = wlddev$income), qtable(r = wldi$region, i = wldi$income))
   expect_equal(pwcor(nv(wlddev)), pwcor(nv(wldi)))
 })
+
+test_that("Id variables are properly preserved in operator methods", {
+  wld1i <- findex_by(fsubset(wlddev, iso3c %==% "DEU"), year)
+  GGDCii <- findex_by(GGDC10S, Variable, Country, Year)
+  GGDCi <- findex_by(GGDC10S, Variable, Country, Year, interact.ids = FALSE)
+  for(FUN in list(L, F, D, Dlog, G, B, W, STD)) {
+      expect_identical(names(FUN(wld1i, cols = "PCGDP", stub = FALSE)), c("year", "PCGDP"))
+      expect_identical(names(FUN(wld1i, cols = "PCGDP", keep.ids = FALSE, stub = FALSE)), "PCGDP")
+      expect_identical(names(FUN(wldi, cols = "PCGDP", stub = FALSE)), c("country", "year", "PCGDP"))
+      expect_identical(names(FUN(wldi, cols = "PCGDP", keep.ids = FALSE, stub = FALSE)), "PCGDP")
+      expect_identical(names(FUN(GGDCi, cols = "SUM", stub = FALSE)), c("Country", "Variable", "Year", "SUM"))
+      expect_identical(names(FUN(GGDCi, cols = "SUM", keep.ids = FALSE, stub = FALSE)), "SUM")
+      expect_identical(names(FUN(GGDCii, cols = "SUM", stub = FALSE)), c("Country", "Variable", "Year", "SUM"))
+      expect_identical(names(FUN(GGDCii, cols = "SUM", keep.ids = FALSE, stub = FALSE)), "SUM")
+  }
+
+})
+
+


### PR DESCRIPTION
…keep.ids = TRUE, even if only 1 or 3+ indexing variables are used.