### PR TITLE
return modified data in settransform(v)

### DIFF
--- a/R/fsubset_ftransform_fmutate.R
+++ b/R/fsubset_ftransform_fmutate.R
@@ -248,7 +248,7 @@ tfmv <- ftransformv
 
 settransform <- function(.data, ...) {
   assign(as.character(substitute(.data)), ftransform(.data, ...), envir = parent.frame())
-  invisible(.data)
+  invisible(get(as.character(substitute(.data)), envir = parent.frame()))
 }
 # eval.parent(substitute(.data <- get0("ftransform", envir = getNamespace("collapse"))(.data, ...))) # can use `<-`(.data, ftransform(.data,...)) but not faster ..
 
@@ -256,7 +256,7 @@ settfm <- settransform
 
 settransformv <- function(.data, ...) {
   assign(as.character(substitute(.data)), ftransformv(.data, ...), envir = parent.frame())
-  invisible(.data)
+  invisible(get(as.character(substitute(.data)), envir = parent.frame()))
 }
 # eval.parent(substitute(.data <- get0("ftransformv", envir = getNamespace("collapse"))(.data, vars, FUN, ..., apply = apply)))
 

--- a/tests/testthat/test-fsubset-ftransform.R
+++ b/tests/testthat/test-fsubset-ftransform.R
@@ -83,6 +83,14 @@ test_that("ftransform works like base::transform", {
 
 })
 
+test_that("settransform returns modified data", {
+  mtcars1 <- mtcars[1:3,]
+  mtcars2 <- settransform(mtcars1, test1 = 1)
+  expect_equal(mtcars1, mtcars2)
+
+  mtcars2 <- settransformv(mtcars1, is.numeric, round)
+  expect_equal(mtcars1, mtcars2)
+})
 
 test_that("fcompute works well", {
 
@@ -113,6 +121,7 @@ test_that("fcomputev works well", {
                ftransformv(iris, is.numeric, fmean, Species, TRA = "replace", apply = FALSE))
 
 })
+
 
 
 


### PR DESCRIPTION
Return modified data in settransform

The current behavior returns unmodified data, which differs from the value description and produces unexpected behavior in a pipe chain. The added test would fail under the current build.

A potentially breaking change.

Current behavior
``` r
library(collapse)
mtcars1 <- mtcars[1:3,]

mtcars1 |> 
  settransform(mpg2 = mpg*2) |> 
  settransform(mpg4 = mpg2*2)
#> Error in eval(substitute(list(...)), .data, parent.frame()): object 'mpg2' not found
```

<sup>Created on 2023-10-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

