### PR TITLE
Fix linking of OpenMP libraries on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 ## -- compiling for OpenMP
-PKG_CFLAGS = -fopenmp -O3
-PKG_CXXFLAGS = -fopenmp -DSTRICT_R_HEADERS
+PKG_CFLAGS = $(SHLIB_OPENMP_CFLAGS) -O3
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) -DSTRICT_R_HEADERS
 ## -- using C++ 11
 # CXX_STD = CXX11
 ## -- linking for OpenMP
-PKG_LIBS = -fopenmp -lgomp
+PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)


### PR DESCRIPTION
This generalizes the linking of OpenMP libraries on Windows to use macros provided by R, which include the right options or library names appropriate for the system (see https://cran.r-project.org/doc/manuals/R-exts.html#OpenMP-support) This fixes the package to build also with LLVM/clang (and libomp).