### PR TITLE
Explicitly set locale for some test files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,6 @@ Imports: Rcpp (>= 1.0.1)
 LinkingTo: Rcpp
 Suggests: fastverse, data.table, magrittr, kit, xts, zoo, plm, fixest, vars, 
           RcppArmadillo, RcppEigen, tibble, dplyr, ggplot2, scales, microbenchmark, 
-          testthat, covr, knitr, rmarkdown
+          testthat, covr, knitr, rmarkdown, withr
 VignetteBuilder: knitr
 

--- a/tests/testthat/test-GRP.R
+++ b/tests/testthat/test-GRP.R
@@ -91,6 +91,7 @@ expect_identical(lapply(rc, function(x) unattrib(radixorderv(gv(wldNA, x), decre
 
 
 test_that("GRP works as intended", {
+ withr::local_locale(c(LC_COLLATE = "C"))
 
  expect_visible(GRP(unname(as.list(mtcars))))
  expect_visible(GRP(unname(as.list(mtcars)), 8:9))

--- a/tests/testthat/test-qtab.R
+++ b/tests/testthat/test-qtab.R
@@ -1,6 +1,6 @@
 context("qtab")
 
-
+withr::local_locale(c(LC_COLLATE = "C"))
 
 set.seed(101)
 wldNA <- na_insert(wlddev)


### PR DESCRIPTION
I was seeing naming mismatch errors without setting locale to C here.