### PR TITLE
Fix `recode_char` when `regex` and `default` are set

### DIFF
--- a/R/recode_replace.R
+++ b/R/recode_replace.R
@@ -156,9 +156,8 @@ recode_char <- function(X, ..., default = NULL, missing = NULL, regex = FALSE,
         } else {
           repfun <- function(y) if(is.character(y)) {
             z <- scv(y, 1L, y[1L], vind1 = TRUE) # Copy
-            y <- scv(y, nam[1L], default, set, TRUE)
-            scv(y, nam[1L], args[[1L]], TRUE)
-            for(i in seqarg[-1L]) scv(y, grepl(nam[i], z, ignore.case, FALSE, fixed), args[[i]], TRUE, vind1 = TRUE)
+            y <- scv(y, seq_along(y), default, set, vind1 = TRUE)  # Initialize all to default
+            for(i in seqarg) scv(y, grepl(nam[i], z, ignore.case, FALSE, fixed), args[[i]], TRUE, vind1 = TRUE)
             y
           } else y
         }

--- a/tests/testthat/test-recode-replace.R
+++ b/tests/testthat/test-recode-replace.R
@@ -56,7 +56,7 @@ set.seed(101)
 lmiss <- na_insert(letters)
 month.miss <- na_insert(month.name)
 char_dat <- na_insert(char_vars(GGDC10S))
-
+char_nums <- c("-1", "1", "0", "2", "-2")
 options(warn = -1)
 
 test_that("recode_char works well", {
@@ -93,6 +93,9 @@ test_that("recode_char works well", {
   expect_visible(recode_char(char_dat, saharan = "SSA", regex = TRUE, default = "n"))
   expect_visible(recode_char(char_dat, saharan = "SSA", regex = TRUE, default = "n", missing = "c"))
 
+  expect_equal(recode_char(char_nums, "-\\d+" = "negative", "0" = "zero", regex = T), c("negative", "1", "zero", "2", "negative"))
+  expect_equal(recode_char(char_nums, "0" = "zero", "-\\d+" = "negative", default = "positive", regex = T), c("negative", "positive", "zero", "positive", "negative"))
+  expect_equal(recode_char(char_nums, "-\\d+" = "negative", "0" = "zero", default = "positive", regex = T), c("negative", "positive", "zero", "positive", "negative"))
 })
 
 set.seed(101)


### PR DESCRIPTION
Fixes #654.