### PR TITLE
One more case of REALSXP-integer64 conversion

### DIFF
--- a/src/data.table_rbindlist.c
+++ b/src/data.table_rbindlist.c
@@ -74,12 +74,15 @@ void writeValue(SEXP target, SEXP source, const int from, const int n) {
     } break;
     case REALSXP: {
       if (INHERITS(target, char_integer64)) {
-      int64_t *vd = (int64_t *)REAL(target), value = (int64_t)REAL(source)[0];
-      for (int i=from; i<=to; ++i) vd[i] = value;
-    } else {
-      double *vd = REAL(target), value = REAL(source)[0];
-      for (int i=from; i<=to; ++i) vd[i] = value;
-    }
+        int64_t *vd = (int64_t *)REAL(target);
+        int64_t value =
+          (!coerce && INHERITS(target, char_integer64)) ? ((int64_t *)REAL(source))[0]
+          : (int64_t)REAL(source)[0];
+        for (int i=from; i<=to; ++i) vd[i] = value;
+      } else {
+        double *vd = REAL(target), value = REAL(source)[0];
+        for (int i=from; i<=to; ++i) vd[i] = value;
+      }
     } break;
     case CPLXSXP: {
       Rcomplex *vd = COMPLEX(target), value = COMPLEX(source)[0];

--- a/src/data.table_rbindlist.c
+++ b/src/data.table_rbindlist.c
@@ -105,7 +105,7 @@ void writeValue(SEXP target, SEXP source, const int from, const int n) {
       break;
     case REALSXP: {
       if (INHERITS(target, char_integer64)) {
-        if(coerce) {
+        if(coerce || !INHERITS(source, char_integer64)) {
           int64_t *ptgt = (int64_t *)REAL(target) + from;
           const double *ptcol = REAL_RO(source);
           for(int i = 0; i != n; ++i) ptgt[i] = ptcol[i];

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -393,3 +393,12 @@ test_that("rowbind", {
   expect_equal(rowbind(a = mtcars, b = mtcars, idcol = "id"), unlist2d(list(a = mtcars, b = mtcars), idcols = "id", id.factor = TRUE))
   expect_equal(rowbind(a = mtcars, b = mtcars, idcol = "id", id.factor = FALSE), unlist2d(list(a = mtcars, b = mtcars), idcols = "id"))
 })
+
+if (requireNamespace("bit64")) test_that("rowbind + integer64", {
+  # https://github.com/SebKrantz/collapse/issues/697
+  x <- data.frame(a = bit64::as.integer64(1))
+  xi <- data.frame(a = 1L)
+  xd <- data.frame(a = 1)
+  expect_equal(rowbind(x, xi), setRownames(rbind(x, x)))
+  expect_equal(rowbind(x, xd), setRownames(rbind(x, x)))
+})


### PR DESCRIPTION
Unfortunately, giving a `REALSXP` to `rowbind()` will follow the `!coerce` branch and reinterpret the `double`s as `int64_t`s too:

```r
collapse::rowbind(data.frame(a=bit64::as.integer64(1)), data.frame(a=2))
#                     a
# 1                   1
# 2 4611686018427387904
```

I'm less sure about the `LENGTH(source) < n` branch, but I updated it to use the same logic as the one taken during `rowbind()`. Where is it exercised?

See: #697