### PR TITLE
Feat: `fslice` function to slicing data

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -202,6 +202,7 @@ importFrom("stats", "as.formula", "complete.cases", "cor", "cov", "var", "pt",
  export(GRPid)
  export(fcount)
  export(fcountv)
+ export(fslice)
  # export(group_names.GRP)
  export(has_elem)
  export(flm)

--- a/R/fslice.R
+++ b/R/fslice.R
@@ -1,0 +1,66 @@
+fslice <- function(x, ..., n = 1, how = "first", order.by = NULL, na.rm = .op[["na.rm"]], with.ties = TRUE) {
+  # handle grouping
+  if (!missing(...)) {
+    g <- GRP(fselect(x, ...), sort = FALSE, return.order = FALSE, call = FALSE)
+  } else {
+    g <- NULL
+  }
+
+  # convert a proportion to a number if applicable
+  if (n < 1) {
+    if (is.null(g)) {
+      n <- max(1, round(n * fnrow(x)))
+    } else {
+      n <- pmax(1, round(n * g$group.sizes))
+    }
+  }
+
+  # resolve values to order by
+  if (!is.null(order.by)) {
+    if (is.character(order.by) && order.by %in% names(x)) {
+      order.by <- vec(fselect(x, order.by))
+    }
+    if (!is.vector(order.by) || length(order.by) != fnrow(x)) {
+      stop("order.by must be a vector of the same length as the number of rows in x")
+    }
+  }
+
+  # get the right function
+  select_fn <- switch(how,
+    "first" = function(idx) head(idx, n),
+    "last" = function(idx) tail(idx, n),
+    "min" = function(idx) {
+      if (is.null(order.by)) stop("'order.by' must be provided for 'min'")
+      values <- order.by[idx]
+      indices <- radixorderv(values, decreasing = FALSE, na.last = !na.rm)
+      if (with.ties) {
+        threshold <- values[indices[n]]
+        indices <- indices[values[indices] <= threshold]
+      } else {
+        indices <- head(indices, n)
+      }
+      idx[indices]
+    },
+    "max" = function(idx) {
+      if (is.null(order.by)) stop("'order.by' must be provided for 'max'")
+      values <- order.by[idx]
+      indices <- radixorderv(values, decreasing = TRUE, na.last = !na.rm)
+      if (with.ties) {
+        threshold <- values[indices[n]]
+        indices <- indices[values[indices] >= threshold]
+      } else {
+        indices <- head(indices, n)
+      }
+      idx[indices]
+    },
+    stop("Invalid 'how' argument: must be 'first', 'last', 'min', or 'max'")
+  )
+
+  indices <- seq_len(fnrow(x))
+  if (is.null(g)) {
+    selected <- select_fn(indices)
+  } else {
+    selected <- unlist(lapply(split(indices, g$group.id), select_fn))
+  }
+  fsubset(x, selected)
+}

--- a/tests/testthat/test-fslice.R
+++ b/tests/testthat/test-fslice.R
@@ -1,0 +1,106 @@
+context("fslice")
+data("iris")
+
+test_that("fslice works with integers and no grouping", {
+  N <- c(1, 5, 17)
+  for (n in N) {
+    # first
+    expect_equal(
+      dplyr::slice_head(iris, n = n),
+      fslice(iris, n = n)
+    )
+    expect_equal(
+      dplyr::slice_head(iris, n = n),
+      fslice(iris, n = n, how = "first")
+    )
+    # last
+    expect_equal(
+      setRownames(dplyr::slice_tail(iris, n = n)),
+      fslice(iris, n = n, how = "last")
+    )
+    # min
+    expect_equal(
+      iris |> dplyr::slice_min(Petal.Length, n = n),
+      fslice(iris, n = n, how = "min", order.by = "Petal.Length")
+    )
+    # max
+    expect_equal(
+      iris |> dplyr::slice_max(Petal.Length, n = n),
+      fslice(iris, n = n, how = "max", order.by = "Petal.Length")
+    )
+  }
+})
+
+
+test_that("fslice works with proportions and no grouping", {
+  N <- c(0.5, 0.75)
+  for (n in N) {
+    # first
+    expect_equal(
+      dplyr::slice_head(iris, prop = n),
+      fslice(iris, n = n)
+    )
+    expect_equal(
+      dplyr::slice_head(iris, prop = n),
+      fslice(iris, n = n, how = "first")
+    )
+    # last
+    expect_equal(
+      setRownames(dplyr::slice_tail(iris, prop = n)),
+      fslice(iris, n = n, how = "last")
+    )
+    # min
+    expect_equal(
+      iris |> dplyr::slice_min(Petal.Length, prop = n),
+      fslice(iris, n = n, how = "min", order.by = "Petal.Length")
+    )
+    # max
+    expect_equal(
+      iris |> dplyr::slice_max(Petal.Length, prop = n),
+      fslice(iris, n = n, how = "max", order.by = "Petal.Length")
+    )
+  }
+})
+
+
+test_that("fslice works with grouping", {
+  N <- c(1, 5, 17)
+  for (n in N) {
+    # first
+    expect_equal(
+      iris |> dplyr::group_by(Species) |> dplyr::slice_head(n = n) |> as.data.frame(),
+      fslice(iris, "Species", n = n, how = "first")
+    )
+    # last
+    expect_equal(
+      iris |> dplyr::group_by(Species) |> dplyr::slice_tail(n = n) |> as.data.frame(),
+      fslice(iris, "Species", n = n, how = "last")
+    )
+    # min
+    expect_equal(
+      iris |> dplyr::group_by(Species) |> dplyr::slice_min(Petal.Length, n = n) |> as.data.frame(),
+      fslice(iris, "Species", n = n, how = "min", order.by = "Petal.Length")
+    )
+    # max
+    expect_equal(
+      iris |> dplyr::group_by(Species) |> dplyr::slice_max(Petal.Length, n = n) |> as.data.frame(),
+      fslice(iris, "Species", n = n, how = "max", order.by = "Petal.Length")
+    )
+  }
+})
+
+test_that("fslice works without ties", {
+  N <- c(1, 5, 17)
+  for (n in N) {
+    # min
+    expect_equal(
+      iris |> dplyr::group_by(Species) |> dplyr::slice_min(Petal.Length, n = n, with_ties = TRUE) |> as.data.frame(),
+      fslice(iris, "Species", n = n, how = "min", order.by = "Petal.Length", with.ties = TRUE)
+    )
+    # max
+    expect_equal(
+      iris |> dplyr::group_by(Species) |> dplyr::slice_max(Petal.Length, n = n, with_ties = TRUE) |> as.data.frame(),
+      fslice(iris, "Species", n = n, how = "max", order.by = "Petal.Length", with.ties = TRUE)
+    )
+  }
+})


### PR DESCRIPTION
## Description

<!-- 
Provide a brief and concise description of the changes. You can reference existing
issues or pull requests as needed, for example, fixes #1, closes #2, similar to #3.
-->

This request adds `fslice` function that provides a unified interface to slice (grouped) data and is similar to `slice_max`, `slice_min`, `slice_head` and `slice_tail` functions in `dplyr`. Closes #725.

## Main Changes

- Implemented `fslice` function that support slicing over first/last/min and max values
- Added basic tests for `fslice`

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where applicable.

## Additional Context

- `devtools::check()` passed successfully
- Tests are basic and do not cover many edge cases
- The implementation is not very `collapse`-ish, but it does outperform `dplyr` equivalents by a large margin:

``` r
n <- 25
microbenchmark(
  iris |> group_by(Species) |> slice_max(Petal.Length, n = n) |> as.data.frame(),
  fslice(iris, "Species", n = n, how = "max", order.by = "Petal.Length")
)
#> Unit: microseconds
#>                                                                         expr      min
#>  as.data.frame(slice_max(group_by(iris, Species), Petal.Length,      n = n)) 1242.669
#>       fslice(iris, "Species", n = n, how = "max", order.by = "Petal.Length")   67.158
#>         lq       mean    median        uq     max neval
#>  1288.4455 1387.81720 1342.2785 1380.3265 5817.08   100
#>    78.3305   94.49352   90.0155  106.3335  168.92   100
```

<sup>Created on 2025-02-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>