### PR TITLE
Set .datatable.aware=TRUE

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,4 @@
+.datatable.aware <- TRUE
 
 do_collapse_mask <- function(clpns, mask) {
   if(!is.character(mask)) stop("Option collapse_mask needs to be character typed")


### PR DESCRIPTION
I was seeing the obscure test failures like:

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-pivot.R:65:5): wide pivots work properly ────────────────────────
Error in `eval(code, test_env)`: object 'PCGDP' not found
Backtrace:
    ▆
 1. ├─testthat::expect_equal(...) at test-pivot.R:65:5
 2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
 3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
 4. ├─collapse::dapply(...)
 5. ├─data.table::dcast(...)
 6. │ └─data.table::is.data.table(data)
 7. ├─wldDT[is.finite(PCGDP)]
 8. └─data.table:::`[.data.table`(wldDT, is.finite(PCGDP))
 9.   └─base::`[.data.frame`(x, i)
```

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-indexing.R:52:3): indexed data.table works well ─────────────────
Error in ``[.data.frame`(x, i)`: undefined columns selected
Backtrace:
     ▆
  1. ├─testthat::expect_equal(unindex(wldidt[1:1000]), wlddt[1:1000]) at test-indexing.R:52:3
  2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
  4. ├─collapse::unindex(wldidt[1:1000])
  5. ├─wldidt[1:1000]
  6. └─collapse:::`[.indexed_frame`(wldidt, 1:1000)
  7.   └─base::eval(cal, list(res = res), parent.frame())
  8.     └─base::eval(cal, list(res = res), parent.frame())
  9.       ├─res[1:1000]
 10.       └─data.table:::`[.data.table`(res, 1:1000)
 11.         └─base::`[.data.frame`(x, i)
 ```
 
 My best guess is this is caused  by test sharding (we split the suite up into 12 parts to run it in parallel), and the data.table-awareness part is only getting picked up in certain shards.

The recommended fix here is just to state clearly in your namespace that `[.data.table` should be used wherever possible.
