### PR TITLE
data.table: use growable vectors

### DIFF
--- a/src/data.table_utils.c
+++ b/src/data.table_utils.c
@@ -38,6 +38,7 @@ SEXP setnames(SEXP x, SEXP nam) {
     memcpy(SEXPPTR(newnam), SEXPPTR_RO(nam), l*sizeof(SEXP));
     SET_LEN(newnam, l);
     SET_TRULEN(newnam, n);
+    SET_GROWABLE_BIT(newnam);
     setAttrib(x, R_NamesSymbol, newnam);
     setselfref(x);
     UNPROTECT(1);


### PR DESCRIPTION
## Description

When creating `data.table` lists or their names, set the `GROWABLE_BIT` on them. This ensures that `R_resizeVector` used by `data.table` won't refuse to work with such `data.table`s. Drop the finalizer as `gc()` will count the memory taken by growable vectors correctly.

## Main Changes

* call `SET_GROWABLE_BIT` when setting `TRUELENGTH` in `shallow()` and `setnames()`
* the finalizer is [no longer needed](https://rdatatable-community.github.io/The-Raft/posts/2025-01-13-non-api-use/index.html#:~:text=When%20deallocating%20shortened%20objects%20without%20the%20GROWABLE_BIT%20set)

## Checklist

- [x] I have performed a self-review of my code.
  * `R CMD check` passes (except for cryptic vignette problems) with `data.table` from CRAN and from current `master`.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where applicable.

## Additional Context

Please let me know how you would like to deal with `SET_GROWABLE_BIT` not being an API entry point. It could be hidden as are other non-API entry points, or the code could make use of [`R_allocResizableVector`](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Resizing-vectors-1) and backport it for R < 4.6.