### PR TITLE
Improve speed of fsum

### DIFF
--- a/src/fsum.c
+++ b/src/fsum.c
@@ -1,26 +1,42 @@
 #include "collapse_c.h"
 // #include <R_ext/Altrep.h>
 
+#define N_ACC 4 // number of accumulators
+
 double fsum_double_impl(const double *restrict px, const int narm, const int l) {
-  double sum;
+  double sum, partial_sums[N_ACC] = {0.0};
+  int remainder;
   if(narm == 1) {
     int j = 1;
     sum = px[0];
     while(ISNAN(sum) && j!=l) sum = px[j++];
     if(j != l) {
-      #pragma omp simd reduction(+:sum)
-      for(int i = j; i < l; ++i) sum += NISNAN(px[i]) ? px[i] : 0.0;
+      remainder = j + (l - j) % N_ACC;
+      for(int i = j; i < remainder; ++i) sum += NISNAN(px[i]) ? px[i] : 0.0;
+      #pragma omp simd reduction(+:partial_sums[:N_ACC])
+      for(int i = remainder; i < l; i += N_ACC) {
+        for(int k = 0; k < N_ACC; ++k) partial_sums[k] += NISNAN(px[i + k]) ? px[i + k] : 0.0;
+      }
+      for(int k = 0; k < N_ACC; ++k) sum += partial_sums[k];
     }
   } else {
     sum = 0;
+    remainder = l % N_ACC;
     if(narm) {
-      #pragma omp simd reduction(+:sum)
-      for(int i = 0; i < l; ++i) sum += NISNAN(px[i]) ? px[i] : 0.0;
+      for(int i = 0; i < remainder; ++i) sum += NISNAN(px[i]) ? px[i] : 0.0;
+      #pragma omp simd reduction(+:partial_sums[:N_ACC])
+      for(int i = remainder; i < l; i += N_ACC) {
+        for(int k = 0; k < N_ACC; ++k) partial_sums[k] += NISNAN(px[i + k]) ? px[i + k] : 0.0;
+      }
     } else {
-     // Should just be fast, don't stop for NA's
-      #pragma omp simd reduction(+:sum)
-      for(int i = 0; i < l; ++i) sum += px[i];
+      // Should just be fast, don't stop for NA's
+      for(int i = 0; i < remainder; ++i) sum += px[i];
+      #pragma omp simd reduction(+:partial_sums[:N_ACC])
+      for(int i = remainder; i < l; i += N_ACC) {
+        for(int k = 0; k < N_ACC; ++k) partial_sums[k] += px[i + k];
+      }
     }
+    for(int k = 0; k < N_ACC; ++k) sum += partial_sums[k];
   }
   return sum;
 }
@@ -46,19 +62,30 @@ void fsum_double_g_impl(double *restrict pout, const double *restrict px, const 
 }
 
 double fsum_double_omp_impl(const double *restrict px, const int narm, const int l, const int nthreads) {
-  double sum;
+  double sum, partial_sums[N_ACC] = {0.0};
+  int remainder;
   if(narm) {
     int j = 1;
     sum = px[0];
     while(ISNAN(sum) && j != l) sum = px[j++];
     if(j != l) {
-      #pragma omp parallel for simd num_threads(nthreads) reduction(+:sum)
-      for(int i = j; i < l; ++i) sum += NISNAN(px[i]) ? px[i] : 0.0;
+      remainder = j + (l - j) % N_ACC;
+      for(int i = j; i < remainder; ++i) sum += NISNAN(px[i]) ? px[i] : 0.0;
+      #pragma omp parallel for simd num_threads(nthreads) reduction(+:partial_sums[:N_ACC])
+      for(int i = remainder; i < l; i += N_ACC) {
+        for(int k = 0; k < N_ACC; ++k) partial_sums[k] += NISNAN(px[i + k]) ? px[i + k] : 0.0;
+      }
+      for(int k = 0; k < N_ACC; ++k) sum += partial_sums[k];
     } else if(narm == 2) sum = 0.0;
   } else {
     sum = 0;
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:sum)
-    for(int i = 0; i < l; ++i) sum += px[i]; // Cannot have break statements in OpenMP for loop
+    remainder = l % N_ACC;
+    for(int i = 0; i < remainder; ++i) sum += px[i];
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:partial_sums[:N_ACC])
+    for(int i = remainder; i < l; i += N_ACC) {
+      for(int k = 0; k < N_ACC; ++k) partial_sums[k] += px[i + k];
+    }
+    for(int k = 0; k < N_ACC; ++k) sum += partial_sums[k];
   }
   return sum;
 }
@@ -101,8 +128,14 @@ double fsum_weights_impl(const double *restrict px, const double *restrict pw, c
       for(int i = 0; i < l; ++i) sum += (NISNAN(px[i]) && NISNAN(pw[i])) ? px[i] * pw[i] : 0.0;
     } else {
       // Also here speed is key...
-      #pragma omp simd reduction(+:sum)
-      for(int i = 0; i < l; ++i) sum += px[i] * pw[i];
+      double partial_sums[N_ACC] = {0.0};
+      const int remainder = l % N_ACC;
+      for(int i = 0; i < remainder; ++i) sum += px[i] * pw[i];
+      #pragma omp simd reduction(+:partial_sums[:N_ACC])
+      for(int i = remainder; i < l; i += N_ACC) {
+        for(int k = 0; k < N_ACC; ++k) partial_sums[k] += px[i + k] * pw[i + k];
+      }
+      for(int k = 0; k < N_ACC; ++k) sum += partial_sums[k];
     }
   }
   return sum;
@@ -140,8 +173,14 @@ double fsum_weights_omp_impl(const double *restrict px, const double *restrict p
     } else sum = narm == 1 ? NA_REAL : 0.0;
   } else {
     sum = 0;
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:sum)
-    for(int i = 0; i < l; ++i) sum += px[i] * pw[i];
+    double partial_sums[N_ACC] = {0.0};
+    const int remainder = l % N_ACC;
+    for(int i = 0; i < remainder; ++i) sum += px[i] * pw[i];
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:partial_sums[:N_ACC])
+    for(int i = remainder; i < l; i += N_ACC) {
+      for(int k = 0; k < N_ACC; ++k) partial_sums[k] += px[i + k] * pw[i + k];
+    }
+    for(int k = 0; k < N_ACC; ++k) sum += partial_sums[k];
   }
   return sum;
 }


### PR DESCRIPTION
## Description

Utilized multiple accumulators in `fsum` to enhance instruction throughput. This led to a 2x performance improvement in certain cases.

Closes #824. Similar to #826 and #827.

## Main Changes

- Improved speed of `fsum` by using multiple accumulators

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where applicable.

## Additional Context

I tried to modify the integer-based sums and the grouped sums, but their loop bodies were too complex to benefit from this technique, so I reverted my changes. Similarly, there was no improvement in the speed of the weighted sums when `na.rm = TRUE`.

Benchmarks were performed on an AMD Ryzen 5 7600X CPU (x86_64).

```R
library(collapse)

n <- 1e6L

set.seed(0L)
x <- rnorm(n)
x_int <- sample.int(1e3L, size = n, replace = TRUE)
w <- runif(n)

bench::mark(
  # Doubles
  sum(x, na.rm = TRUE),
  sum(x, na.rm = FALSE),
  fsum(x),
  fsum(x, na.rm = FALSE),
  fsum(x, nthreads = 4),
  fsum(x, na.rm = FALSE, nthreads = 4),
  # Doubles, weighted
  fsum(x, w = w),
  fsum(x, w = w, na.rm = FALSE),
  fsum(x, w = w, nthreads = 4),
  fsum(x, w = w, na.rm = FALSE, nthreads = 4),
  # Integers
  sum(x_int, na.rm = TRUE),
  sum(x_int, na.rm = FALSE),
  fsum(x_int),
  fsum(x_int, na.rm = FALSE),
  fsum(x_int, nthreads = 4),
  fsum(x_int, na.rm = FALSE, nthreads = 4),
  iterations = 1e3L,
  check = FALSE
)
```

Only showing iterations/second for comparison purposes:

```
                                                Before  After Improvement
 1 sum(x, na.rm = TRUE)                            738.     -
 2 sum(x, na.rm = FALSE)                           700.     -
 3 fsum(x)                                        3070.  5942.      1.94x
 4 fsum(x, na.rm = FALSE)                         3074.  6070.      1.97x
 5 fsum(x, nthreads = 4)                         11570. 21874.      1.89x
 6 fsum(x, na.rm = FALSE, nthreads = 4)          11764. 22379.      1.90x
 7 fsum(x, w = w)                                 1543.     -
 8 fsum(x, w = w, na.rm = FALSE)                  3046.  5883.      1.93x
 9 fsum(x, w = w, nthreads = 4)                   5995.     -
10 fsum(x, w = w, na.rm = FALSE, nthreads = 4)   11695. 22041.      1.88x
11 sum(x_int, na.rm = TRUE)                       2331.     -
12 sum(x_int, na.rm = FALSE)                      2333.     -
13 fsum(x_int)                                    2318.     -
14 fsum(x_int, na.rm = FALSE)                     2325.     -
15 fsum(x_int, nthreads = 4)                     18980.     -
16 fsum(x_int, na.rm = FALSE, nthreads = 4)      32257.     -
```