### PR TITLE
perf: apply multiple-accumulator SIMD optimization to fmean.c (#824)

### DIFF
--- a/src/fmean.c
+++ b/src/fmean.c
@@ -3,30 +3,41 @@
 
 // Adapted from fsum.c
 
+#define FMEAN_N_ACC 4
+
 double fmean_double_impl(const double *restrict px, const int narm, const int l) {
   if(narm) {
     int j = 1, n = 1;
     double mean = px[0];
     while(ISNAN(mean) && j!=l) mean = px[j++];
     if(j != l) {
-      #pragma omp simd reduction(+:mean,n)
-      for(int i = j; i < l; ++i) {
-          int tmp = NISNAN(px[i]);
-          mean += tmp ? px[i] : 0.0;
-          n += tmp ? 1 : 0;
+      int rem = (l - j) % FMEAN_N_ACC;
+      for(int i = j; i < j + rem; ++i) {
+        int tmp = NISNAN(px[i]);
+        mean += tmp ? px[i] : 0.0;
+        n += tmp;
       }
+      double acc[FMEAN_N_ACC] = {0};
+      int nacc[FMEAN_N_ACC] = {0};
+      for(int i = j + rem; i < l; i += FMEAN_N_ACC) {
+        for(int k = 0; k < FMEAN_N_ACC; ++k) {
+          int tmp = NISNAN(px[i+k]);
+          acc[k] += tmp ? px[i+k] : 0.0;
+          nacc[k] += tmp;
+        }
+      }
+      for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += acc[k]; n += nacc[k]; }
     }
-    return  mean / n;
+    return mean / n;
   }
   double mean = 0;
-  #pragma omp simd reduction(+:mean)
-  for(int i = 0; i < l; ++i) {
-    // if(ISNAN(px[i])) {
-    //   mean = px[i];
-    //   break;
-    // }
-    mean += px[i];
+  int rem = l % FMEAN_N_ACC;
+  for(int i = 0; i < rem; ++i) mean += px[i];
+  double acc[FMEAN_N_ACC] = {0};
+  for(int i = rem; i < l; i += FMEAN_N_ACC) {
+    for(int k = 0; k < FMEAN_N_ACC; ++k) acc[k] += px[i+k];
   }
+  for(int k = 0; k < FMEAN_N_ACC; ++k) mean += acc[k];
   return mean / l;
 }
 
@@ -34,16 +45,33 @@ double fmean_double_omp_impl(const double *restrict px, const int narm, const in
   double mean = 0;
   if(narm) {
     int n = 0;
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:mean,n)
-    for(int i = 0; i < l; ++i) {
+    int rem = l % FMEAN_N_ACC;
+    double acc[FMEAN_N_ACC] = {0};
+    int nacc[FMEAN_N_ACC] = {0};
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:acc[:FMEAN_N_ACC],nacc[:FMEAN_N_ACC])
+    for(int i = 0; i < l - rem; i += FMEAN_N_ACC) {
+      for(int k = 0; k < FMEAN_N_ACC; ++k) {
+        int tmp = NISNAN(px[i+k]);
+        acc[k] += tmp ? px[i+k] : 0.0;
+        nacc[k] += tmp;
+      }
+    }
+    for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += acc[k]; n += nacc[k]; }
+    for(int i = l - rem; i < l; ++i) {
       int tmp = NISNAN(px[i]);
       mean += tmp ? px[i] : 0.0;
-      n += tmp ? 1 : 0;
+      n += tmp;
     }
     return n == 0 ? NA_REAL : mean / n;
   }
-  #pragma omp parallel for simd num_threads(nthreads) reduction(+:mean)
-  for(int i = 0; i < l; ++i) mean += px[i];
+  int rem = l % FMEAN_N_ACC;
+  double acc[FMEAN_N_ACC] = {0};
+  #pragma omp parallel for simd num_threads(nthreads) reduction(+:acc[:FMEAN_N_ACC])
+  for(int i = 0; i < l - rem; i += FMEAN_N_ACC) {
+    for(int k = 0; k < FMEAN_N_ACC; ++k) acc[k] += px[i+k];
+  }
+  for(int k = 0; k < FMEAN_N_ACC; ++k) mean += acc[k];
+  for(int i = l - rem; i < l; ++i) mean += px[i];
   return mean / l;
 }
 
@@ -78,44 +106,72 @@ double fmean_weights_impl(const double *restrict px, const double *restrict pw, 
     sumw = pw[j];
     mean = px[j] * sumw;
     if(j != end) {
-      #pragma omp simd reduction(+:mean,sumw)
-      for(int i = j+1; i < l; ++i) {
+      int start = j + 1;
+      int rem = (l - start) % FMEAN_N_ACC;
+      for(int i = start; i < start + rem; ++i) {
         int tmp = NISNAN(px[i]) && NISNAN(pw[i]);
         mean += tmp ? px[i] * pw[i] : 0.0;
         sumw += tmp ? pw[i] : 0.0;
       }
+      double macc[FMEAN_N_ACC] = {0};
+      double wacc[FMEAN_N_ACC] = {0};
+      for(int i = start + rem; i < l; i += FMEAN_N_ACC) {
+        for(int k = 0; k < FMEAN_N_ACC; ++k) {
+          int tmp = NISNAN(px[i+k]) && NISNAN(pw[i+k]);
+          macc[k] += tmp ? px[i+k] * pw[i+k] : 0.0;
+          wacc[k] += tmp ? pw[i+k] : 0.0;
+        }
+      }
+      for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += macc[k]; sumw += wacc[k]; }
     }
   } else {
     mean = 0, sumw = 0;
-    #pragma omp simd reduction(+:mean,sumw)
-    for(int i = 0; i < l; ++i) {
-      // if(ISNAN(px[i]) || ISNAN(pw[i])) {
-      //   mean = px[i] + pw[i];
-      //   break;
-      // }
-      mean += px[i] * pw[i];
-      sumw += pw[i];
+    int rem = l % FMEAN_N_ACC;
+    for(int i = 0; i < rem; ++i) { mean += px[i] * pw[i]; sumw += pw[i]; }
+    double macc[FMEAN_N_ACC] = {0};
+    double wacc[FMEAN_N_ACC] = {0};
+    for(int i = rem; i < l; i += FMEAN_N_ACC) {
+      for(int k = 0; k < FMEAN_N_ACC; ++k) {
+        macc[k] += px[i+k] * pw[i+k];
+        wacc[k] += pw[i+k];
+      }
     }
+    for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += macc[k]; sumw += wacc[k]; }
   }
   return mean / sumw;
 }
 
 double fmean_weights_omp_impl(const double *restrict px, const double *restrict pw, const int narm, const int l, const int nthreads) {
   double mean = 0, sumw = 0;
+  int rem = l % FMEAN_N_ACC;
+  double macc[FMEAN_N_ACC] = {0};
+  double wacc[FMEAN_N_ACC] = {0};
   if(narm) {
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:mean,sumw)
-    for(int i = 0; i < l; ++i) {
-      int tmp = NISNAN(px[i]) + NISNAN(pw[i]) == 2; // && doesn't vectorize for some reason
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:macc[:FMEAN_N_ACC],wacc[:FMEAN_N_ACC])
+    for(int i = 0; i < l - rem; i += FMEAN_N_ACC) {
+      for(int k = 0; k < FMEAN_N_ACC; ++k) {
+        int tmp = NISNAN(px[i+k]) + NISNAN(pw[i+k]) == 2; // && doesn't vectorize for some reason
+        macc[k] += tmp ? px[i+k] * pw[i+k] : 0.0;
+        wacc[k] += tmp ? pw[i+k] : 0.0;
+      }
+    }
+    for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += macc[k]; sumw += wacc[k]; }
+    for(int i = l - rem; i < l; ++i) {
+      int tmp = NISNAN(px[i]) + NISNAN(pw[i]) == 2;
       mean += tmp ? px[i] * pw[i] : 0.0;
       sumw += tmp ? pw[i] : 0.0;
     }
     if(mean == 0 && sumw == 0) sumw = NA_REAL;
   } else {
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:mean,sumw)
-    for(int i = 0; i < l; ++i) {
-      mean += px[i] * pw[i];
-      sumw += pw[i];
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:macc[:FMEAN_N_ACC],wacc[:FMEAN_N_ACC])
+    for(int i = 0; i < l - rem; i += FMEAN_N_ACC) {
+      for(int k = 0; k < FMEAN_N_ACC; ++k) {
+        macc[k] += px[i+k] * pw[i+k];
+        wacc[k] += pw[i+k];
+      }
     }
+    for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += macc[k]; sumw += wacc[k]; }
+    for(int i = l - rem; i < l; ++i) { mean += px[i] * pw[i]; sumw += pw[i]; }
   }
   return mean / sumw;
 }
@@ -173,19 +229,35 @@ double fmean_int_impl(const int *restrict px, const int narm, const int l) {
 double fmean_int_omp_impl(const int *restrict px, const int narm, const int l, const int nthreads) {
   long long mean = 0;
   double dmean;
+  int rem = l % FMEAN_N_ACC;
   if(narm) {
     int n = 0;
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:mean,n)
-    for(int i = 0; i < l; ++i) {
+    long long acc[FMEAN_N_ACC] = {0};
+    int nacc[FMEAN_N_ACC] = {0};
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:acc[:FMEAN_N_ACC],nacc[:FMEAN_N_ACC])
+    for(int i = 0; i < l - rem; i += FMEAN_N_ACC) {
+      for(int k = 0; k < FMEAN_N_ACC; ++k) {
+        int tmp = px[i+k] != NA_INTEGER;
+        acc[k] += tmp ? px[i+k] : 0;
+        nacc[k] += tmp;
+      }
+    }
+    for(int k = 0; k < FMEAN_N_ACC; ++k) { mean += acc[k]; n += nacc[k]; }
+    for(int i = l - rem; i < l; ++i) {
       int tmp = px[i] != NA_INTEGER;
       mean += tmp ? px[i] : 0;
-      n += tmp ? 1 : 0;
+      n += tmp;
     }
     dmean = n == 0 ? NA_REAL : (double)mean / n;
   } else {
     if(px[0] == NA_INTEGER || px[l-1] == NA_INTEGER) return NA_REAL;
-    #pragma omp parallel for simd num_threads(nthreads) reduction(+:mean)
-    for(int i = 0; i < l; ++i) mean += px[i];
+    long long acc[FMEAN_N_ACC] = {0};
+    #pragma omp parallel for simd num_threads(nthreads) reduction(+:acc[:FMEAN_N_ACC])
+    for(int i = 0; i < l - rem; i += FMEAN_N_ACC) {
+      for(int k = 0; k < FMEAN_N_ACC; ++k) acc[k] += px[i+k];
+    }
+    for(int k = 0; k < FMEAN_N_ACC; ++k) mean += acc[k];
+    for(int i = l - rem; i < l; ++i) mean += px[i];
     dmean = (double)mean / l;
   }
   return dmean;


### PR DESCRIPTION
Extends the loop unrolling optimization from PR #828 (fsum.c) to all ungrouped scalar paths in fmean.c, using FMEAN_N_ACC = 4 independent accumulators to break serial dependency chains and enable SIMD auto-vectorization.

Functions updated:
- fmean_double_impl: na.rm=TRUE (dual acc/nacc arrays), na.rm=FALSE (acc array)
- fmean_double_omp_impl: both paths with reduction(+:acc[:N],nacc[:N])
- fmean_weights_impl: both paths with dual macc/wacc arrays
- fmean_weights_omp_impl: both paths with array reduction
- fmean_int_omp_impl: both paths with long long acc arrays

Grouped functions are unchanged — scatter pattern prevents vectorization.

## Description

<!-- 
Provide a brief and concise description of the changes. You can reference existing
issues or pull requests as needed, for example, fixes #1, closes #2, similar to #3.
-->

## Main Changes

<!-- 
List key changes as bullets, for example:
- fixed a bug in `fsum` when NAs are present
- added a new `how` argument to `merge` function
- refactored `utils.R` to improve readability
-->

## Checklist

<!-- 
Make sure you can tick all the boxes:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where applicable.

## Additional Context

<!-- Any other relevant information goes here.-->
