### PR TITLE
Fix claude-opus workflow permissions and model identifier

### DIFF
--- a/.github/workflows/claude-opus.yml
+++ b/.github/workflows/claude-opus.yml
@@ -20,9 +20,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude-opus') || contains(github.event.issue.title, '@claude-opus')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read
     steps:
@@ -40,4 +40,4 @@ jobs:
             actions: read
 
           # Force the container runner to spin up using Claude Opus
-          claude_args: '--model claude-opus-4-7'
+          claude_args: '--model opus'


### PR DESCRIPTION
## Summary
Fixed the claude-opus GitHub Actions workflow to enable the @claude-opus agent to properly create PRs and push code.

## Changes
- Updated permissions from `read` to `write` for contents, pull-requests, and issues
- Fixed model identifier from invalid `claude-opus-4-7` to `opus`

## Impact
The @claude-opus agent will now be able to:
- Create branches
- Push code changes
- Create pull requests
- Respond to issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)