### PR TITLE
Fix claude-opus workflow trigger phrase

### DIFF
--- a/.github/workflows/claude-opus.yml
+++ b/.github/workflows/claude-opus.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: '@claude-opus'
           additional_permissions: |
             actions: read
 


### PR DESCRIPTION
## Summary
Fixed the @claude-opus workflow trigger phrase mismatch that was preventing the agent from executing.

## Problem
The workflow condition correctly triggered on `@claude-opus` mentions, but the claude-code-action inside was still looking for the default `@claude` trigger phrase. This caused the action to exit immediately with "No trigger found, skipping remaining steps."

## Solution
Added `trigger_phrase: '@claude-opus'` to the action configuration to match the workflow's trigger condition.

## Testing
After this change, @claude-opus mentions will properly invoke the Opus model agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)