### PR TITLE
feat: add drop = FALSE support to GRP.default, fgroup_by, fcount, collap (closes #820)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # collapse 2.1.6
 
 * The repo has moved to `fastverse/collapse` and the website to [fastverse.org/collapse](https://fastverse.org/collapse/)---for better visibility and maintenance. Appropriate redirects from the old repo/site have been implemented.
-  Selected people now have access to the repo through the organization account and may respond to issues or submit fixes. 
+  Selected people now have access to the repo through the organization account and may respond to issues or submit fixes.
+
+* `GRP.default()` gains a `drop = TRUE` argument. Setting `drop = FALSE` (and providing at least one factor among the grouping columns) retains all combinations of factor levels with the observed unique values of non-factor grouping columns---the full Cartesian product---similar to `dplyr::group_by(.drop = FALSE)`. Unobserved combinations get `group.sizes` of `0` and `group.starts` of `0L`. Correspondingly, `fgroup_by()`/`gby()` gain a `.drop` argument, and `fcount()`/`fcountv()`/`collap()`/`collapv()` gain a `drop` argument, enabling counts and aggregations that retain empty groups (#820).
 
 * Added new AI-generated interactive/chattable [DeepWiki documentation](https://deepwiki.com/fastverse/collapse).
 

--- a/R/GRP.R
+++ b/R/GRP.R
@@ -95,7 +95,7 @@ GRP.GRP <- function(X, ...) X
 
 GRP.default <- function(X, by = NULL, sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE,
                         return.groups = TRUE, return.order = sort, method = "auto",
-                        call = TRUE, ...) {
+                        drop = TRUE, call = TRUE, ...) {
 
   use.group <- switch(method, auto = !sort, hash = TRUE, radix = FALSE, stop("method needs to be 'auto', 'hash' or 'radix'."))
 
@@ -103,13 +103,13 @@ GRP.default <- function(X, by = NULL, sort = .op[["sort"]], decreasing = FALSE, 
 
   if(is.list(X)) {
     if(inherits(X, "GRP")) return(X)
-    if(is.null(by)) {
+    by_null <- is.null(by)
+    if(by_null) {
       by <- seq_along(unclass(X))
       # # This is so that fgroup_by(iris, Species = GRP(Species)) is possible.
       # if(length(by) == 1L && is.list(.subset2(X, 1L)) && inherits(.subset2(X, 1L), "GRP")) return(.subset2(X, 1L))
       namby <- attr(X, "names")
       if(is.null(namby)) attr(X, "names") <- namby <- paste0("Group.", by)
-      o <- switchGRP(X, na.last, decreasing, return.groups || !use.group, TRUE, sort, use.group)
     } else {
       if(is.call(by)) {
         namby <- all.vars(by, unique = FALSE)
@@ -126,8 +126,26 @@ GRP.default <- function(X, by = NULL, sort = .op[["sort"]], decreasing = FALSE, 
           attr(X, "names") <- paste0("Group.", seq_along(unclass(X))) # best ?
         }
       }
-      o <- switchGRP(.subset(X, by), na.last, decreasing, return.groups || !use.group, TRUE, sort, use.group)
     }
+    # drop = FALSE: full Cartesian product of (factor) levels, computed in C.
+    # Falls through to the existing path when no grouping column is a factor (matches dplyr).
+    if(!drop) {
+      cols <- if(by_null) unclass(X) else .subset(unclass(X), by)
+      if(any(vapply(unattrib(cols), is.factor, TRUE))) {
+        res <- .Call(C_GRP_default_drop, X, cols, namby, return.groups)
+        return(`oldClass<-`(list(N.groups = res[[1L]],
+                              group.id = res[[2L]],
+                              group.sizes = res[[3L]],
+                              groups = if(return.groups) res[[5L]] else NULL,
+                              group.vars = namby,
+                              ordered = c(ordered = NA, sorted = NA),
+                              order = NULL,
+                              group.starts = res[[4L]],
+                              call = if(call) match.call() else NULL), "GRP"))
+      }
+    }
+    o <- switchGRP(if(by_null) X else .subset(X, by),
+                   na.last, decreasing, return.groups || !use.group, TRUE, sort, use.group)
   } else {
    if(length(by)) stop("by can only be used to subset list / data.frame columns")
    namby <- l1orlst(as.character(substitute(X))) # paste(all.vars(call), collapse = ".") # good in all circumstances ?
@@ -382,7 +400,7 @@ GRP.pseries <- function(X, effect = 1L, ..., group.sizes = TRUE, return.groups =
 GRP.pdata.frame <- function(X, effect = 1L, ..., group.sizes = TRUE, return.groups = TRUE, call = TRUE)
   GRP.pseries(X, effect, ..., group.sizes = group.sizes, return.groups = return.groups, call = call)
 
-fgroup_by <- function(.X, ..., sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE, return.groups = TRUE, return.order = sort, method = "auto") {          #   e <- substitute(list(...)) # faster but does not preserve attributes of unique groups !
+fgroup_by <- function(.X, ..., sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE, return.groups = TRUE, return.order = sort, method = "auto", .drop = TRUE) {          #   e <- substitute(list(...)) # faster but does not preserve attributes of unique groups !
   clx <- oldClass(.X)
   oldClass(.X) <- NULL
   m <- match(c("GRP_df", "grouped_df", "data.frame"), clx, nomatch = 0L)
@@ -416,7 +434,7 @@ fgroup_by <- function(.X, ..., sort = .op[["sort"]], decreasing = FALSE, na.last
       } else names(e) <- vars
     }
   }
-  attr(.X, "groups") <- GRP.default(e, NULL, sort, decreasing, na.last, return.groups, return.order, method, FALSE)
+  attr(.X, "groups") <- GRP.default(e, NULL, sort, decreasing, na.last, return.groups, return.order, method, .drop, FALSE)
   # if(any(clx == "sf")) oldClass(.X) <- clx[clx != "sf"]
   # attr(.X, "groups") <- GRP.default(fselect(if(m[2L]) fungroup(.X) else .X, ...), NULL, sort, decreasing, na.last, TRUE, return.order, method, FALSE)
     # Needed: wlddev %>% fgroup_by(country) gives error if dplyr is loaded. Also sf objects etc..

--- a/R/collap.R
+++ b/R/collap.R
@@ -95,7 +95,7 @@ rbindlist_factor <- function(l, idcol = "Function") {
 collap <- function(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wFUN = fsum, custom = NULL,
                    ...,
                    keep.by = TRUE, keep.w = TRUE, keep.col.order = TRUE, sort = .op[["sort"]], decreasing = FALSE,
-                   na.last = TRUE, return.order = sort, method = "auto", parallel = FALSE, mc.cores = 2L,
+                   na.last = TRUE, return.order = sort, method = "auto", drop = TRUE, parallel = FALSE, mc.cores = 2L,
                    return = c("wide","list","long","long_dupl"), give.names = "auto") {
 
   return <- switch(return[1L], wide = 1L, list = 2L, long = 3L, long_dupl = 4L, stop("Unknown return output option"))
@@ -127,14 +127,14 @@ collap <- function(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wF
       numby <- ckmatch(all.vars(by), nam)
       if(ncustoml) v <- if(is.null(cols)) seq_along(X)[-numby] else cols2int(cols, X, nam)
     }
-    by <- GRP.default(X, numby, sort, decreasing, na.last, keep.by, return.order, method, call = FALSE)
+    by <- GRP.default(X, numby, sort, decreasing, na.last, keep.by, return.order, method, drop = drop, call = FALSE)
   } else if(is.atomic(by)) {
     numby <- 0L
     if(ncustoml) if(is.null(cols)) vl <- FALSE else v <- cols2int(cols, X, nam)
-    by <- GRP.default(`names<-`(list(by), l1orlst(as.character(substitute(by)))), NULL, sort, decreasing, na.last, keep.by, return.order, method, call = FALSE)
+    by <- GRP.default(`names<-`(list(by), l1orlst(as.character(substitute(by)))), NULL, sort, decreasing, na.last, keep.by, return.order, method, drop = drop, call = FALSE)
   } else {
     if(ncustoml) if(is.null(cols)) vl <- FALSE else v <- cols2int(cols, X, nam)
-    if(!is_GRP(by)) by <- GRP.default(by, NULL, sort, decreasing, na.last, keep.by, return.order, method, call = FALSE)
+    if(!is_GRP(by)) by <- GRP.default(by, NULL, sort, decreasing, na.last, keep.by, return.order, method, drop = drop, call = FALSE)
     numby <- rep(0L, length(by[[5L]]))
     if(keep.by && !vl && any(m <- nam %in% by[[5L]])) {
       v <- whichv(m, FALSE)
@@ -322,7 +322,7 @@ collap <- function(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wF
 # collapv: allows vector input to by and w
 collapv <- function(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wFUN = fsum, custom = NULL, ...,
                     keep.by = TRUE, keep.w = TRUE, keep.col.order = TRUE, sort = .op[["sort"]], decreasing = FALSE,
-                    na.last = TRUE, return.order = sort, method = "auto", parallel = FALSE, mc.cores = 2L,
+                    na.last = TRUE, return.order = sort, method = "auto", drop = TRUE, parallel = FALSE, mc.cores = 2L,
                     return = c("wide","list","long","long_dupl"), give.names = "auto") {
 
   return <- switch(return[1L], wide = 1L, list = 2L, long = 3L, long_dupl = 4L, stop("Unknown return output option"))
@@ -343,7 +343,7 @@ collapv <- function(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, w
 
   # identifying by
   numby <- cols2int(by, X, nam)
-  by <- GRP.default(X, numby, sort, decreasing, na.last, keep.by, return.order, method, call = FALSE)
+  by <- GRP.default(X, numby, sort, decreasing, na.last, keep.by, return.order, method, drop = drop, call = FALSE)
   if(ncustoml) v <- if(is.null(cols)) seq_along(X)[-numby] else cols2int(cols, X, nam)
 
 

--- a/R/fcount.R
+++ b/R/fcount.R
@@ -34,18 +34,20 @@ fcount_core <- function(x, g, w = NULL, name = "N", add = FALSE) {
   condalc(copyMostAttributes(c(res, `names<-`(list(g$group.sizes), name[1L])), res), inherits(x, "data.table"))
 }
 
-fcount <- function(x, ..., w = NULL, name = "N", add = FALSE, sort = FALSE, decreasing = FALSE) {
+fcount <- function(x, ..., w = NULL, name = "N", add = FALSE, sort = FALSE, decreasing = FALSE, drop = TRUE) {
   if(is.list(x)) w <- eval(substitute(w), x, parent.frame())
   else x <- qDF(x)
   if(is.character(add)) add <- switch(add, gv =, group_vars = 2L, stop("add must be TRUE, FALSE or group_vars (gv)")) # add = "g", "groups" or "group_vars"
   # Note: this code duplication with GRP() is needed for GRP() to capture x (using substitute) if x is atomic.
   # if(is.atomic(x)) `names<-`(list(x), l1orlst(as.character(substitute(x)))) else
-  g <- if(missing(...)) GRP(x, sort = sort, decreasing = decreasing, return.groups = !add, return.order = FALSE, call = FALSE) else
-    GRP.default(fselect(x, ...), sort = sort, decreasing = decreasing, return.groups = !add, return.order = FALSE, call = FALSE)
+  g <- if(missing(...)) {
+         if(inherits(x, "grouped_df")) GRP(x, sort = sort, decreasing = decreasing, return.groups = !add, return.order = FALSE, call = FALSE)
+         else GRP.default(x, sort = sort, decreasing = decreasing, return.groups = !add, return.order = FALSE, drop = drop, call = FALSE)
+       } else GRP.default(fselect(x, ...), sort = sort, decreasing = decreasing, return.groups = !add, return.order = FALSE, drop = drop, call = FALSE)
   fcount_core(x, g, w, name, add)
 }
 
-fcountv <- function(x, cols = NULL, w = NULL, name = "N", add = FALSE, sort = FALSE, ...) {
+fcountv <- function(x, cols = NULL, w = NULL, name = "N", add = FALSE, sort = FALSE, drop = TRUE, ...) {
   # Safe enough ? or only allow character ? what about collapv() ?, extra option ?
   # if(length(w) == 1L && is.list(x) && length(unclass(x)) > 1L && (is.character(w) || is.integer(w) || (is.numeric(w) && w %% 1 < 1e-6)))
   if(is.atomic(x)) x <- qDF(x)
@@ -54,7 +56,9 @@ fcountv <- function(x, cols = NULL, w = NULL, name = "N", add = FALSE, sort = FA
     if(is.null(w)) stop("Unknown column: ", w)
   }
   if(is.character(add)) add <- switch(add, gv =, group_vars = 2L, stop("add must be TRUE, FALSE or group_vars (gv)")) # add = "g", "groups" or "group_vars"
-  g <- if(is.null(cols)) GRP(x, sort = sort, return.groups = !add, return.order = FALSE, call = FALSE, ...) else
-    GRP.default(colsubset(x, cols), sort = sort, return.groups = !add, return.order = FALSE, call = FALSE, ...)
+  g <- if(is.null(cols)) {
+         if(inherits(x, "grouped_df")) GRP(x, sort = sort, return.groups = !add, return.order = FALSE, call = FALSE, ...)
+         else GRP.default(x, sort = sort, return.groups = !add, return.order = FALSE, drop = drop, call = FALSE, ...)
+       } else GRP.default(colsubset(x, cols), sort = sort, return.groups = !add, return.order = FALSE, drop = drop, call = FALSE, ...)
   fcount_core(x, g, w, name, add)
 }

--- a/man/GRP.Rd
+++ b/man/GRP.Rd
@@ -37,7 +37,7 @@ GRP(X, \dots)
 
 \method{GRP}{default}(X, by = NULL, sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE,
     return.groups = TRUE, return.order = sort, method = "auto",
-    call = TRUE, \dots)
+    drop = TRUE, call = TRUE, \dots)
 
 \method{GRP}{factor}(X, \dots, group.sizes = TRUE, drop = FALSE, return.groups = TRUE,
     call = TRUE)
@@ -70,12 +70,14 @@ greorder(x, g, \dots)
 
 # Fast, class-agnostic pendant to dplyr::group_by for use with fast functions, see details
 fgroup_by(.X, \dots, sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE,
-          return.groups = TRUE, return.order = sort, method = "auto")
+          return.groups = TRUE, return.order = sort, method = "auto",
+          .drop = TRUE)
 # Standard-evaluation analogue (slim wrapper around GRP.default(), for programming)
 group_by_vars(X, by = NULL, ...)
 # Shorthand for fgroup_by
 gby(.X, \dots, sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE,
-    return.groups = TRUE, return.order = sort, method = "auto")
+    return.groups = TRUE, return.order = sort, method = "auto",
+    .drop = TRUE)
 
 # Get grouping columns from a grouped data frame created with dplyr::group_by or fgroup_by
 fgroup_vars(X, return = "data")
@@ -111,7 +113,7 @@ fungroup(X, \dots)
 
   \item{group.sizes}{logical. \code{TRUE} tabulates factor levels using \code{\link{tabulate}} to create a vector of group sizes; \code{FALSE} leaves that slot empty when converting from factors.}
 
-  \item{drop}{logical. \code{TRUE} efficiently drops unused factor levels beforehand using \code{\link{fdroplevels}}.}
+  \item{drop, .drop}{logical. In \code{GRP.factor}: \code{TRUE} efficiently drops unused factor levels beforehand using \code{\link{fdroplevels}}. In \code{GRP.default}/\code{fgroup_by}/\code{gby}: if \code{FALSE} and any of the grouping columns are factors, the full Cartesian product of factor levels (combined with the observed unique values of any non-factor grouping columns) is used to define the groups. Group combinations not present in the data have \code{group.sizes} of \code{0} and \code{group.starts} of \code{0L}. This is analogous to \code{dplyr::group_by(.drop = FALSE)} and useful for aggregations or counts that should retain empty groups (e.g. \code{fcount(..., drop = FALSE)} or \code{collap(..., drop = FALSE)}). The default is \code{TRUE} (only observed combinations are kept). Only applies to the default method - has no effect for grouped data frames or factor/qG/pseries/pdata.frame inputs.}
 
   \item{call}{logical. \code{TRUE} calls \code{\link{match.call}} and saves it in the final slot of the GRP object.}
 

--- a/man/collap.Rd
+++ b/man/collap.Rd
@@ -22,14 +22,14 @@ It performs simple and weighted aggregations, multi-type aggregations automatica
 collap(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wFUN = fsum,
        custom = NULL, \dots, keep.by = TRUE, keep.w = TRUE, keep.col.order = TRUE,
        sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE, return.order = sort,
-       method = "auto", parallel = FALSE, mc.cores = 2L,
+       method = "auto", drop = TRUE, parallel = FALSE, mc.cores = 2L,
        return = c("wide","list","long","long_dupl"), give.names = "auto")
 
 # Programmer function: allows column names and indices input to `by` and `w` arguments
 collapv(X, by, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wFUN = fsum,
         custom = NULL, \dots, keep.by = TRUE, keep.w = TRUE, keep.col.order = TRUE,
         sort = .op[["sort"]], decreasing = FALSE, na.last = TRUE, return.order = sort,
-        method = "auto", parallel = FALSE, mc.cores = 2L,
+        method = "auto", drop = TRUE, parallel = FALSE, mc.cores = 2L,
         return = c("wide","list","long","long_dupl"), give.names = "auto")
 
 # Auxiliary function: for grouped data ('grouped_df') input + non-standard evaluation
@@ -51,6 +51,7 @@ collapg(X, FUN = fmean, catFUN = fmode, cols = NULL, w = NULL, wFUN = fsum,
 \item{keep.w}{logical. \code{FALSE} will omit weight variable from the output i.e. no aggregation of the weights. \code{TRUE} aggregates and adds weights, even if passed externally as a vector (unlike other \emph{collapse} functions).}
 \item{keep.col.order}{logical. Retain original column order post-aggregation.}
 \item{sort, decreasing, na.last, return.order, method}{logical / character. Arguments passed to \code{\link{GRP.default}} and affecting the row-order in the aggregated data frame and the grouping algorithm.}
+\item{drop}{logical. \code{FALSE} retains zero-count rows for unobserved combinations of factor levels among the grouping columns (analogous to \code{dplyr::group_by(.drop = FALSE)}). The corresponding rows in the aggregated output will contain values produced by the aggregation functions for empty groups (e.g. \code{NA} for \code{fmean}, \code{0} for \code{fsum}). See \code{\link{GRP}} (\code{drop} argument of \code{GRP.default}).}
 \item{parallel}{logical. Use \code{\link{mclapply}} instead of \code{lapply} to parallelize the computation at the column level. Not available for Windows.}
 \item{mc.cores}{integer. Argument to \code{\link{mclapply}} setting the number of cores to use, default is 2.}
 \item{return}{character. Control the output format when aggregating with multiple functions or performing custom aggregation. "wide" (default) returns a wider data frame with added columns for each additional function. "list" returns a list of data frames - one for each function. "long" adds a column "Function" and row-binds the results from different functions using \code{data.table::rbindlist}. "long_dupl" is a special option for aggregating multi-type data using multiple \code{FUN} but only one \code{catFUN} or vice-versa. In that case the format is long and data aggregated using only one function is duplicated. See Examples.}

--- a/man/fcount.Rd
+++ b/man/fcount.Rd
@@ -10,10 +10,10 @@ A much faster replacement for \code{dplyr::count}.
 }
 \usage{
 fcount(x, ..., w = NULL, name = "N", add = FALSE,
-      sort = FALSE, decreasing = FALSE)
+      sort = FALSE, decreasing = FALSE, drop = TRUE)
 
 fcountv(x, cols = NULL, w = NULL, name = "N", add = FALSE,
-        sort = FALSE, ...)
+        sort = FALSE, drop = TRUE, ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -25,6 +25,7 @@ fcountv(x, cols = NULL, w = NULL, name = "N", add = FALSE,
   \item{add}{\code{TRUE} adds the count column to \code{x}. Alternatively \code{add = "group_vars"} (or \code{add = "gv"} for parsimony) can be used to retain only the variables selected for counting in \code{x} and the count.}
   \item{sort, decreasing}{arguments passed to \code{\link{GRP}} affecting the order of rows in the output (if \code{add = FALSE}), and the algorithm used for counting. In general, \code{sort = FALSE} is faster unless data is already sorted by the columns used for counting.
 }
+  \item{drop}{logical. \code{FALSE} retains zero-count rows for unobserved combinations of factor levels (analogous to \code{dplyr::count(..., .drop = FALSE)}); applies only when at least one of the counted columns is a factor. See \code{\link{GRP}} (\code{drop} argument of \code{GRP.default}).}
 }
 \value{
 If \code{x} is a list, an object of the same type as \code{x} with a column (\code{name}) added at the end giving the count. Otherwise, if \code{x} is atomic, a data frame returned from \code{\link[=qDF]{qDF(x)}} with the count column added. By default (\code{add = FALSE}) only the unique rows of \code{x} of the columns used for counting are returned.

--- a/src/ExportSymbols.c
+++ b/src/ExportSymbols.c
@@ -126,6 +126,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"C_geteptr", (DL_FUNC) &geteptr, 1},
   {"C_fcrosscolon", (DL_FUNC) &fcrosscolon, 4},
   {"C_fwtabulate", (DL_FUNC) &fwtabulate, 4},
+  {"C_GRP_default_drop", (DL_FUNC) &GRP_default_drop_C, 4},
   {"C_vecgcd", (DL_FUNC) &vecgcd, 1},
   {"C_issorted", (DL_FUNC) &Cissorted, 2},
   {"C_all_funs", (DL_FUNC) &all_funs, 1},

--- a/src/collapse_c.h
+++ b/src/collapse_c.h
@@ -107,6 +107,7 @@ SEXP createeptr(SEXP x);
 SEXP geteptr(SEXP x);
 SEXP fcrosscolon(SEXP x, SEXP ngp, SEXP y, SEXP ckna);
 SEXP fwtabulate(SEXP x, SEXP w, SEXP ngp, SEXP ckna);
+SEXP GRP_default_drop_C(SEXP X, SEXP cols, SEXP namby, SEXP retgrp_);
 SEXP vecgcd(SEXP x);
 SEXP all_funs(SEXP x);
 SEXP unlock_collapse_namespace(SEXP env);

--- a/src/small_helper.c
+++ b/src/small_helper.c
@@ -470,6 +470,181 @@ SEXP fwtabulate(SEXP x, SEXP w, SEXP ngp, SEXP ckna) {
   return tab;
 }
 
+// ---------------------------------------------------------------------------
+// GRP.default with drop = FALSE: build full Cartesian product of factor levels
+// (and observed unique values for non-factor columns) as the grouping universe.
+//
+// X:        original list / data.frame (used for class preservation on groups)
+// cols:     list of grouping columns (already subset from X by `by`)
+// namby:    character vector of names for the groups data.frame
+// retgrp_:  scalar logical, whether to return the groups data.frame
+//
+// Returns list(N.groups, group.id, group.sizes, group.starts, groups).
+// `group.id` is 1-based and free of NAs (NAs become explicit factor levels).
+// `group.sizes`/`group.starts` have length Ng (= product of per-column sizes),
+// with 0 in `group.sizes` and 0 in `group.starts` for combinations not observed.
+// ---------------------------------------------------------------------------
+SEXP GRP_default_drop_C(SEXP X, SEXP cols, SEXP namby, SEXP retgrp_) {
+  if(TYPEOF(cols) != VECSXP) error("Internal error: cols must be a list");
+  int nc = length(cols), retgrp = asLogical(retgrp_);
+  if(nc == 0) error("GRP.default(drop = FALSE) requires at least one grouping column");
+
+  int n = length(VECTOR_ELT(cols, 0));
+  int nprotect = 0;
+  SEXP codes_list = PROTECT(allocVector(VECSXP, nc)); ++nprotect; // per-col 1-based codes
+  SEXP levs_list  = PROTECT(allocVector(VECSXP, nc)); ++nprotect; // per-col level/unique-value vectors
+  int *isfac = (int*) R_alloc(nc, sizeof(int));
+  int *pnl   = (int*) R_alloc(nc, sizeof(int));
+
+  long long Ng_ll = 1;
+  for(int j = 0; j < nc; ++j) {
+    SEXP col = VECTOR_ELT(cols, j);
+    if(length(col) != n) error("All grouping columns must have equal length");
+
+    if(isFactor(col)) {
+      isfac[j] = 1;
+      SEXP lev = getAttrib(col, R_LevelsSymbol);
+      int nl = length(lev);
+      const int *pcol = INTEGER_RO(col);
+
+      // Does the factor already have an explicit NA level? Does the column contain NAs?
+      int hasNAlev = 0, na_lev_pos = 0;
+      for(int k = 0; k < nl; ++k) {
+        if(STRING_ELT(lev, k) == NA_STRING) { hasNAlev = 1; na_lev_pos = k + 1; break; }
+      }
+      int colHasNA = 0;
+      for(int i = 0; i < n; ++i) if(pcol[i] == NA_INTEGER) { colHasNA = 1; break; }
+
+      if(colHasNA) {
+        // Remap NA codes to an NA level (adding one if necessary). Mirrors addNA2().
+        int nl_new = hasNAlev ? nl : nl + 1;
+        int na_code = hasNAlev ? na_lev_pos : nl_new;
+        SEXP new_lev = lev;
+        if(!hasNAlev) {
+          new_lev = PROTECT(allocVector(STRSXP, nl_new)); ++nprotect;
+          for(int k = 0; k < nl; ++k) SET_STRING_ELT(new_lev, k, STRING_ELT(lev, k));
+          SET_STRING_ELT(new_lev, nl, NA_STRING);
+        }
+        SEXP codes = PROTECT(allocVector(INTSXP, n)); ++nprotect;
+        int *pcodes = INTEGER(codes);
+        for(int i = 0; i < n; ++i) pcodes[i] = pcol[i] == NA_INTEGER ? na_code : pcol[i];
+        SET_VECTOR_ELT(codes_list, j, codes);
+        SET_VECTOR_ELT(levs_list,  j, new_lev);
+        pnl[j] = nl_new;
+      } else {
+        // Use factor codes / levels as-is (no allocation)
+        SET_VECTOR_ELT(codes_list, j, col);
+        SET_VECTOR_ELT(levs_list,  j, lev);
+        pnl[j] = nl;
+      }
+    } else {
+      isfac[j] = 0;
+      // Non-factor: hash the column. groupVec returns 1-based codes; NAs are
+      // assigned a dedicated code (na.included), so combined IDs are NA-free too.
+      SEXP g = PROTECT(groupVec(col, retgrp ? ScalarLogical(1) : ScalarLogical(0), ScalarLogical(0)));
+      ++nprotect;
+      int ng = asInteger(getAttrib(g, sym_n_groups));
+      SET_VECTOR_ELT(codes_list, j, g);
+      pnl[j] = ng;
+      if(retgrp) {
+        // Unique values in hash-encounter order = col[starts]
+        SEXP starts = getAttrib(g, sym_starts);
+        SEXP uvals  = PROTECT(allocVector(TYPEOF(col), ng)); ++nprotect;
+        subsetVectorRaw(uvals, col, starts, /*anyNA=*/ false);
+        copyMostAttrib(col, uvals);
+        SET_VECTOR_ELT(levs_list, j, uvals);
+      }
+    }
+
+    Ng_ll *= pnl[j];
+    if(Ng_ll > INT_MAX)
+      error("Total number of group combinations (%lld) exceeds INT_MAX. Consider using drop = TRUE.", Ng_ll);
+  }
+  int Ng = (int) Ng_ll;
+
+  // --- Combined group.id via stride arithmetic (cf. fcrosscolon) ---
+  SEXP gid = PROTECT(allocVector(INTSXP, n)); ++nprotect;
+  int *pgid = INTEGER(gid);
+  const int *p0 = INTEGER_RO(VECTOR_ELT(codes_list, 0));
+  memcpy(pgid, p0, sizeof(int) * n);
+  long long stride = pnl[0];
+  for(int j = 1; j < nc; ++j) {
+    const int *pj = INTEGER_RO(VECTOR_ELT(codes_list, j));
+    int s = (int) stride;
+    for(int i = 0; i < n; ++i) pgid[i] += (pj[i] - 1) * s;
+    stride *= pnl[j];
+  }
+
+  // --- group.sizes (cf. fwtabulate) and group.starts (first occurrence) ---
+  SEXP gs  = PROTECT(allocVector(INTSXP, Ng)); ++nprotect;
+  SEXP gst = PROTECT(allocVector(INTSXP, Ng)); ++nprotect;
+  int *pgs = INTEGER(gs), *pgst = INTEGER(gst);
+  memset(pgs,  0, sizeof(int) * Ng);
+  memset(pgst, 0, sizeof(int) * Ng);
+  for(int i = 0; i < n; ++i) {
+    int g = pgid[i] - 1;
+    ++pgs[g];
+    if(pgst[g] == 0) pgst[g] = i + 1;
+  }
+
+  // --- groups data.frame: enumerate every combination in column-major order ---
+  SEXP groups = R_NilValue;
+  if(retgrp) {
+    PROTECT(groups = allocVector(VECSXP, nc)); ++nprotect;
+    long long stride_j = 1;
+    for(int j = 0; j < nc; ++j) {
+      int nlj = pnl[j], sj = (int) stride_j;
+      SEXP lev = VECTOR_ELT(levs_list, j);
+
+      if(isfac[j]) {
+        // Build a fresh factor with the same levels and class as the input column
+        SEXP newcol = PROTECT(allocVector(INTSXP, Ng));
+        int *pnew = INTEGER(newcol);
+        for(int g = 0; g < Ng; ++g) pnew[g] = (g / sj) % nlj + 1;
+        setAttrib(newcol, R_LevelsSymbol, lev);
+        SEXP origcol = VECTOR_ELT(cols, j);
+        SEXP cls = getAttrib(origcol, R_ClassSymbol);
+        setAttrib(newcol, R_ClassSymbol, cls);
+        SET_VECTOR_ELT(groups, j, newcol);
+        UNPROTECT(1);
+      } else {
+        // Non-factor: subset the per-column unique values by the index vector
+        SEXP idx = PROTECT(allocVector(INTSXP, Ng));
+        int *pidx = INTEGER(idx);
+        for(int g = 0; g < Ng; ++g) pidx[g] = (g / sj) % nlj + 1;
+        SEXP newcol = PROTECT(allocVector(TYPEOF(lev), Ng));
+        subsetVectorRaw(newcol, lev, idx, /*anyNA=*/ false);
+        copyMostAttrib(lev, newcol);
+        SET_VECTOR_ELT(groups, j, newcol);
+        UNPROTECT(2);
+      }
+      stride_j *= nlj;
+    }
+    // Names and (if applicable) class of groups data.frame: copy class etc. from X
+    // (like C_subsetDT). Only add data.frame row.names if X is itself a data.frame,
+    // matching the drop = TRUE behaviour for plain list inputs.
+    namesgets(groups, namby);
+    if(inherits(X, "data.frame")) {
+      if(isObject(X)) copyMostAttrib(X, groups);
+      SEXP rn = PROTECT(allocVector(INTSXP, 2));
+      INTEGER(rn)[0] = NA_INTEGER;
+      INTEGER(rn)[1] = -Ng;
+      setAttrib(groups, R_RowNamesSymbol, rn);
+      UNPROTECT(1);
+    }
+  }
+
+  // --- Assemble result list ---
+  SEXP res = PROTECT(allocVector(VECSXP, 5)); ++nprotect;
+  SET_VECTOR_ELT(res, 0, ScalarInteger(Ng));
+  SET_VECTOR_ELT(res, 1, gid);
+  SET_VECTOR_ELT(res, 2, gs);
+  SET_VECTOR_ELT(res, 3, gst);
+  SET_VECTOR_ELT(res, 4, groups);
+  UNPROTECT(nprotect);
+  return res;
+}
+
 // Recursive function: doesn't work in C99 Standard
 // int fgcd(int a, int b) {
 //    if(b == 0) return a;

--- a/tests/testthat/test-GRP.R
+++ b/tests/testthat/test-GRP.R
@@ -519,3 +519,79 @@ test_that("funique works well", {
               lapply(GGDC10S, function(x) unattrib(funique(x))))
 
 })
+
+test_that("GRP.default(drop = FALSE) preserves unused factor levels", {
+
+  df <- data.frame(
+    f1 = factor(c("a", "b", "a"), levels = c("a", "b", "c")),
+    f2 = factor(c("x", "x", "y"), levels = c("x", "y", "z")),
+    v  = c(1, 2, 3)
+  )
+
+  # Basic Cartesian product
+  g <- GRP.default(df, ~ f1 + f2, drop = FALSE)
+  expect_equal(g$N.groups, 9L)
+  expect_equal(g$group.sizes, c(1L, 1L, 0L, 1L, 0L, 0L, 0L, 0L, 0L))
+  expect_equal(length(g$group.id), 3L)
+  expect_false(anyNA(g$group.id))
+  expect_equal(nrow(g$groups), 9L)
+  expect_equal(names(g$groups), c("f1", "f2"))
+  # group.starts: first occurrence, 0 for unobserved
+  expect_equal(g$group.starts[g$group.sizes == 0L], rep(0L, 6L))
+
+  # drop = TRUE returns observed groups only
+  gt <- GRP.default(df, ~ f1 + f2, drop = TRUE)
+  expect_equal(gt$N.groups, 3L)
+
+  # Falls through to default path when no factor columns
+  df2 <- data.frame(x = c(1, 2, 1), y = c(10, 20, 10))
+  g2 <- GRP.default(df2, drop = FALSE)
+  expect_equal(g2$N.groups, GRP.default(df2, drop = TRUE)$N.groups)
+
+  # Factor with NAs: NA becomes an explicit level
+  df3 <- data.frame(f = factor(c("a", "b", NA, "a"), levels = c("a", "b", "c")))
+  g3 <- GRP.default(df3, ~ f, drop = FALSE)
+  expect_equal(g3$N.groups, 4L)
+  expect_false(anyNA(g3$group.id))
+
+  # Mix factor + non-factor: non-factor uses observed unique values
+  df4 <- data.frame(
+    f = factor(c("a", "b", "a", "c"), levels = c("a", "b", "c", "d")),
+    x = c(10, 20, 10, 20)
+  )
+  g4 <- GRP.default(df4, ~ f + x, drop = FALSE)
+  expect_equal(g4$N.groups, 8L)  # 4 levels x 2 observed values
+  expect_equal(sum(g4$group.sizes), 4L)
+
+  # fgroup_by with .drop = FALSE
+  gdf <- fgroup_by(df, f1, f2, .drop = FALSE)
+  gg <- attr(gdf, "groups")
+  expect_equal(gg$N.groups, 9L)
+
+  # Aggregation through grouped df preserves empty groups (as NA / 0)
+  res <- fsum(fgroup_by(df, f1, f2, .drop = FALSE), v)
+  expect_equal(nrow(res), 9L)
+
+  # fcount preserves levels
+  fc <- fcount(df, f1, f2, drop = FALSE)
+  expect_equal(nrow(fc), 9L)
+  expect_equal(fc$N, c(1L, 1L, 0L, 1L, 0L, 0L, 0L, 0L, 0L))
+
+  # data.table class is preserved
+  if(requireNamespace("data.table", quietly = TRUE)) {
+    dt <- data.table::as.data.table(df)
+    fcd <- fcount(dt, f1, f2, drop = FALSE)
+    expect_true(data.table::is.data.table(fcd))
+  }
+
+  # tibble class is preserved
+  if(requireNamespace("tibble", quietly = TRUE)) {
+    tb <- tibble::as_tibble(df)
+    fct <- fcount(tb, f1, f2, drop = FALSE)
+    expect_true(inherits(fct, "tbl_df"))
+  }
+
+  # collap with drop = FALSE
+  rc <- collap(df, ~ f1 + f2, drop = FALSE)
+  expect_equal(nrow(rc), 9L)
+})


### PR DESCRIPTION
## Summary

Closes #820. Implements per the proposal in [comment #4148327549](https://github.com/fastverse/collapse/issues/820#issuecomment-4148327549) and the approach refinements requested in [comment #4471849836](https://github.com/fastverse/collapse/issues/820#issuecomment-4471849836):

- `GRP.default()` gains a new `drop = TRUE` argument. With `drop = FALSE`, and at least one factor in the grouping columns, the full Cartesian product of factor levels × observed unique values of non-factor columns becomes the grouping universe. Empty groups get `group.sizes = 0` and `group.starts = 0L`. The behaviour mirrors `dplyr::group_by(.drop = FALSE)`.
- `fgroup_by()` / `gby()` gain a `.drop = TRUE` argument that is forwarded to `GRP.default()`.
- `fcount()`, `fcountv()`, `collap()`, `collapv()` gain a `drop = TRUE` argument so that counts and aggregations can retain empty groups.

## Implementation notes

Per @SebKrantz's request, the R loop building the level-combination table is implemented in C (`src/small_helper.c` → `GRP_default_drop_C`, registered as `C_GRP_default_drop`):

- Factor columns: codes/levels used directly. NAs are remapped to an explicit NA level (`addNA2()` semantics) so the combined group.id is NA-free.
- Non-factor columns: hashed via `groupVec()`. Unique values are obtained by subsetting `col[starts]` with type-aware `subsetVectorRaw()` (preserving classes such as Date).
- Combined group.id is built via stride arithmetic, with an overflow guard against products exceeding `INT_MAX`.
- The `groups` data.frame is built in column-major order. Class preservation is done with `copyMostAttrib(X, groups)` mirroring `C_subsetDT`, so `data.table`, `tibble`, etc. are preserved. Row names are only added when X is itself a data.frame, matching the `drop = TRUE` behaviour for plain list inputs.

When no grouping column is a factor (e.g. plain numeric/character grouping), `drop = FALSE` falls through to the existing radix/hash path — consistent with `dplyr` which also only acts on factor variables.

## Test plan

- [x] All existing `tests/testthat/test-GRP.R` pass (242 PASS / 0 FAIL)
- [x] All existing `tests/testthat/test-collap.R` pass (188 PASS / 0 FAIL)
- [x] All existing `tests/testthat/test-fsum.R` pass (846 PASS / 0 FAIL)
- [x] All existing `tests/testthat/test-fmutate.R` pass (43 PASS / 0 FAIL)
- [x] New `test_that("GRP.default(drop = FALSE) preserves unused factor levels", ...)` block in `tests/testthat/test-GRP.R` covering:
  - Basic Cartesian product of factor levels
  - Fall-through to default path when no factors are present
  - Factor with NAs (NA becomes an explicit level)
  - Mix of factor + non-factor grouping columns
  - `fgroup_by(.drop = FALSE)` + `fsum()` aggregation
  - `fcount(drop = FALSE)` equivalence with `dplyr::count(.drop = FALSE)`
  - `data.table` and `tibble` class preservation on the groups frame
  - `collap(drop = FALSE)` with multiple factor groups
- [x] Documentation updates verified with `tools::checkRd()` for `man/GRP.Rd`, `man/fcount.Rd`, `man/collap.Rd`
- [x] `NEWS.md` updated under `collapse 2.1.6`

## Files changed

- `src/small_helper.c` – new `GRP_default_drop_C` (~170 lines)
- `src/collapse_c.h` – declaration
- `src/ExportSymbols.c` – `C_GRP_default_drop` registration
- `R/GRP.R` – `drop` arg in `GRP.default`, `.drop` in `fgroup_by`
- `R/fcount.R` – `drop` arg in `fcount`/`fcountv`
- `R/collap.R` – `drop` arg in `collap`/`collapv`
- `man/GRP.Rd`, `man/fcount.Rd`, `man/collap.Rd` – documentation
- `NEWS.md` – release note
- `tests/testthat/test-GRP.R` – tests for the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)