### PR TITLE
docs: fix typo 'must not be numeric' -> 'need not be numeric' in flag.Rd

### DIFF
--- a/man/flag.Rd
+++ b/man/flag.Rd
@@ -62,7 +62,7 @@ flag(x, n = 1, \dots)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{x}{a vector / time series, (time series) matrix, data frame, 'indexed_series' ('pseries'), 'indexed_frame' ('pdata.frame') or grouped data frame ('grouped_df'). Data must not be numeric.}
+  \item{x}{a vector / time series, (time series) matrix, data frame, 'indexed_series' ('pseries'), 'indexed_frame' ('pdata.frame') or grouped data frame ('grouped_df'). Data need not be numeric.}
   \item{n}{integer. A vector indicating the lags / leads to compute (passing negative integers to \code{flag} or \code{L} computes leads, passing negative integers to \code{F} computes lags).}
   \item{g}{a factor, \code{\link{GRP}} object, or atomic vector / list of vectors (internally grouped with \code{\link{group}}) used to group \code{x}. \emph{Note} that without \code{t}, all values in a group need to be consecutive and in the right order. See Details.}
   \item{by}{\emph{data.frame method}: Same as \code{g}, but also allows one- or two-sided formulas i.e. \code{~ group1} or \code{var1 + var2 ~ group1 + group2}. See Examples.}


### PR DESCRIPTION
## Summary

Fixes a documentation typo in  line 65.

**Before:** "Data must not be numeric."
**After:** "Data need not be numeric."

## Problem

The // functions work on any data type including character, logical, and factor vectors — not just numeric. The original wording "must not be numeric" incorrectly implies the function rejects numeric data, when it actually accepts all types.

Verified with:


## Validation

-  passes with no output (no errors/warnings)
- 1 line changed, minimal diff

## Related

- Companion PR #850 fixes qsu.Rd typos (separate issue)