### PR TITLE
docs: fix typo 'must not be numeric' -> 'need not be numeric' in varying.Rd

### DIFF
--- a/man/varying.Rd
+++ b/man/varying.Rd
@@ -40,7 +40,7 @@ varying(x, ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-    \item{x}{a vector, matrix, data frame, 'indexed_series' ('pseries'), 'indexed_frame' ('pdata.frame') or grouped data frame ('grouped_df'). Data must not be numeric.}
+    \item{x}{a vector, matrix, data frame, 'indexed_series' ('pseries'), 'indexed_frame' ('pdata.frame') or grouped data frame ('grouped_df'). Data need not be numeric.}
 
 \item{g}{a factor, \code{GRP} object, atomic vector (internally converted to factor) or a list of vectors / factors (internally converted to a \code{GRP} object) used to group \code{x}.}
 


### PR DESCRIPTION
## Summary

Fixed a documentation typo in `man/varying.Rd` line 43 that incorrectly states the data type requirements for `varying`.

**Before:** "Data must not be numeric."
**After:** "Data need not be numeric."

## Problem

The `varying` function works on all data types including numeric — the examples even show `varying(wlddev)` which contains numeric columns. The original wording "must not be numeric" incorrectly implies the function rejects numeric data.

Verified with:
```r
library(collapse)
varying(mtcars, mtcars)  # works: TRUE
varying(iris.Length, iris)  # works: TRUE
varying(c("a","a","b"))  # works: TRUE
```

This is the same typo that was fixed in `flag.Rd` (PR #851).

## Validation

- `tools::checkRd('man/varying.Rd')` passes (no output = no errors)
- 1 line changed in 1 file: `man/varying.Rd`