### PR TITLE
docs: fix @param scale type 'logical' -> 'numeric' in fgrowth.Rd

### DIFF
--- a/man/fgrowth.Rd
+++ b/man/fgrowth.Rd
@@ -74,7 +74,7 @@ fgrowth(x, n = 1, diff = 1, \dots)
   \item{cols}{\emph{data.frame method}: Select columns to compute growth rates using a function, column names, indices or a logical vector. Default: All numeric variables. \emph{Note}: \code{cols} is ignored if a two-sided formula is passed to \code{by}.}
   \item{fill}{value to insert when vectors are shifted. Default is \code{NA}. }
   \item{logdiff}{logical. Compute log-difference growth rates instead of exact growth rates. See Details.}
-  \item{scale}{logical. Scale factor post-applied to growth rates, default is 100 which gives growth rates in percentage terms. See Details.}
+  \item{scale}{numeric. Scale factor post-applied to growth rates, default is 100 which gives growth rates in percentage terms. See Details.}
   \item{power}{numeric. Apply a power to annualize or compound growth rates e.g. \code{fgrowth(AirPassengers, 12, power = 1/12)} is equivalent to \code{((AirPassengers/flag(AirPassengers, 12))^(1/12)-1)*100}.}
   \item{stubs}{logical. \code{TRUE} (default) will rename all computed columns by adding a prefix "L\code{n}G\code{diff}." / "F\code{n}G\code{diff}.", or "L\code{n}Dlog\code{diff}." / "F\code{n}Dlog\code{diff}." if \code{logdiff = TRUE}.}
     \item{shift}{\emph{pseries / pdata.frame methods}: character. \code{"time"} or \code{"row"}. See \code{\link{flag}} for details.}


### PR DESCRIPTION
## Summary

Fixed the `@param scale` type annotation in `man/fgrowth.Rd` from `logical` to `numeric`.

**Before:** `\item{scale}{logical. Scale factor post-applied to growth rates...}`
**After:** `\item{scale}{numeric. Scale factor post-applied to growth rates...}`

## Problem

The `scale` parameter in `fgrowth()`/`G()` accepts numeric values (default `100` for percentage growth rates), not logical. The source code in `R/fdiff_fgrowth.R` confirms all method signatures use `scale = 100`, and the parameter is used in arithmetic operations like `baselog(x) %*=% scale`.

Adjacent parameters in the same file are correctly typed:
- `logdiff` → `logical` ✓
- `power` → `numeric` ✓
- `scale` → `logical` ✗ (should be `numeric`)

## Validation

- `tools::checkRd('man/fgrowth.Rd')` — passes (no output = no errors)
- Verified `scale` accepts numeric values: `fgrowth(AirPassengers, scale=100)`, `fgrowth(AirPassengers, scale=1)`, `fgrowth(AirPassengers, scale=1000)` all work correctly with expected proportional results.
- 1 file changed, 1 line modified

## Files Changed

| File | Change | Type |
|------|--------|------|
| man/fgrowth.Rd | `logical` → `numeric` | Documentation (Rd) |

## Companion PRs

- #850: fix typo 'momens' → 'moments' in qsu.Rd
- #851: fix typo 'must not be numeric' → 'need not be numeric' in flag.Rd
- #852: fix typo 'must not be numeric' → 'need not be numeric' in varying.Rd