### PR TITLE
docs: fix swapped matrix dimensions in fFtest.Rd

### DIFF
--- a/man/fFtest.Rd
+++ b/man/fFtest.Rd
@@ -35,7 +35,7 @@ Factors and continuous regressors are efficiently projected out using \code{\lin
 \emph{Note} that an intercept is always added by \code{\link{fhdwithin}}, so it is not necessary to include an intercept in data supplied to \code{exc} / \code{X}.
 }
 \value{
-A 5 x 3 numeric matrix of statistics. The columns contain statistics:
+A 3 x 5 numeric matrix of statistics. The columns contain statistics:
 \enumerate{
 \item the R-squared of the model
 \item the numerator degrees of freedom i.e. the number of variables (k) and used factor levels if \code{full.df = TRUE}


### PR DESCRIPTION
## Summary

Fixes swapped matrix dimensions in `man/fFtest.Rd` line 38.

**Before:** `A 5 x 3 numeric matrix of statistics`
**After:** `A 3 x 5 numeric matrix of statistics`

## Problem

The `fFtest()` function returns a 3×5 matrix (3 rows × 5 columns), not 5×3 as documented. The source code `R/fFtest.R` line 70 creates the matrix with `nrow = 3L, ncol = 5L`, and the subsequent Rd text correctly lists 5 column statistics and 3 row categories.

Verified with:
```r
library(collapse)
y <- rnorm(100); X <- matrix(rnorm(200), 100, 2); exc <- rnorm(100)
res <- fFtest(y, exc, X)
dim(res)  # [1] 3 5
```

## Validation

- `tools::checkRd('man/fFtest.Rd')` — passes (no output = no errors)
- Runtime verification confirms 3 rows × 5 columns
- 1 file changed, 1 line modified

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/fFtest.Rd | 1 | Documentation (hand-written Rd) |