### PR TITLE
docs: fix duplicated 'bounded at' in fcumsum.Rd

### DIFF
--- a/man/fcumsum.Rd
+++ b/man/fcumsum.Rd
@@ -53,7 +53,7 @@ By default the cumulative sum is computed in the order in which elements appear 
 
 The \emph{pseries} and \emph{pdata.frame} methods assume that the last factor in the \link[=findex]{index} is the time-variable and the rest are grouping variables. The time-variable is passed to \code{radixorderv} and used for ordered computation, so that cumulative sums are accurately computed regardless of whether the panel-data is ordered or balanced.
 
-\code{fcumsum} explicitly supports integers. Integers in R are bounded at bounded at +-2,147,483,647, and an integer overflow error will be provided if the cumulative sum (within any group) exceeds +-2,147,483,647. In that case data should be converted to double beforehand.
+\code{fcumsum} explicitly supports integers. Integers in R are bounded at +-2,147,483,647, and an integer overflow error will be provided if the cumulative sum (within any group) exceeds +-2,147,483,647. In that case data should be converted to double beforehand.
 
 }
 \value{


### PR DESCRIPTION
## Summary

Fix duplicated phrase in  line 56.

**Before:** "Integers in R are bounded at bounded at +-2,147,483,647"
**After:** "Integers in R are bounded at +-2,147,483,647"

## Problem

The word "bounded at" was accidentally repeated twice in the sentence describing integer limits for . This is a simple copy-editing typo.

## Validation

- `tools::checkRd('man/fcumsum.Rd')` — passes (no output = no errors)
- 1 file changed, 1 line modified