### PR TITLE
docs: fix typo 'loosing' -> 'losing' in dapply.Rd

### DIFF
--- a/man/dapply.Rd
+++ b/man/dapply.Rd
@@ -23,7 +23,7 @@ dapply(X, FUN, \dots, MARGIN = 2, parallel = FALSE, mc.cores = 1L,
   \item{drop}{logical. If the result has only one row or one column, \code{drop = TRUE} will drop dimensions and return a (named) atomic vector.}
 }
 \details{
-\code{dapply} is an efficient command to apply functions to rows or columns of data without loosing information (attributes) about the data or changing the classes or format of the data. It is principally an efficient wrapper around \code{\link{lapply}} and works as follows:
+\code{dapply} is an efficient command to apply functions to rows or columns of data without losing information (attributes) about the data or changing the classes or format of the data. It is principally an efficient wrapper around \code{\link{lapply}} and works as follows:
 
 \itemize{
 \item Save the attributes of \code{X}.


### PR DESCRIPTION
## Summary

Fixes a spelling error in `man/dapply.Rd` line 26.

**Before:** "without loosing information (attributes)"
**After:** "without losing information (attributes)"

## Problem

"Loosing" is a common misspelling of "losing". The correct word in this context is "losing" — `dapply` preserves attributes without *losing* information about the data.

## Validation

- `tools::checkRd('man/dapply.Rd')` — passes (no output = no errors)
- 1 file changed, 1 line modified

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/dapply.Rd | 1 | Documentation (hand-written Rd) |