### PR TITLE
docs: fix typo 'weighed' -> 'weighted' in fmode.Rd

### DIFF
--- a/man/fmode.Rd
+++ b/man/fmode.Rd
@@ -79,7 +79,7 @@ It is possible that multiple values have the same mode (the maximum frequency or
 \code{fmode} preserves all the attributes of the objects it is applied to (apart from names or row-names which are adjusted as necessary in grouped operations). If a data frame is passed to \code{fmode} and \code{drop = TRUE} (the default), \code{\link{unlist}} will be called on the result, which might not be sensible depending on the data at hand.
 }
 \value{
-The (\code{w} weighted) statistical mode of \code{x}, grouped by \code{g}, or (if \code{\link{TRA}} is used) \code{x} transformed by its (grouped, weighed) mode. %See also Details.
+The (\code{w} weighted) statistical mode of \code{x}, grouped by \code{g}, or (if \code{\link{TRA}} is used) \code{x} transformed by its (grouped, weighted) mode. %See also Details.
 }
 \seealso{
 \code{\link{fmean}}, \code{\link{fmedian}}, \link[=fast-statistical-functions]{Fast Statistical Functions}, \link[=collapse-documentation]{Collapse Overview}


### PR DESCRIPTION
## Summary

Fixed spelling error "weighed" → "weighted" in `man/fmode.Rd` line 82.

**Before:** `x transformed by its (grouped, weighed) mode`
**After:** `x transformed by its (grouped, weighted) mode`

## Problem

The `\value` section of `fmode.Rd` uses "weighed" (past tense of "to weigh") where "weighted" (adjective meaning "having weights applied") is correct. The term "weighted" is used consistently throughout the rest of the file and all other collapse Rd files (125+ occurrences of "weighted", 0 of "weighed").

## Validation

- `tools::checkRd('man/fmode.Rd')` — passes (no output = no errors)
- 1 file changed, 1 line modified

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/fmode.Rd | 1 | Documentation (hand-written Rd) |