### PR TITLE
docs: fix typo 'Demonstaration' → 'Demonstration' in fquantile.Rd

### DIFF
--- a/man/fquantile.Rd
+++ b/man/fquantile.Rd
@@ -92,7 +92,7 @@ for (i in 5:9) print(all_obj_equal(fquantile(mtcars$mpg, type = i),
                                    fquantile(mtcars$mpg, type = i, w = w, o = o),
                                     quantile(mtcars$mpg, type = i)))
 
-## Demonstaration: weighted quantiles type 7 in R
+## Demonstration: weighted quantiles type 7 in R
 wquantile7R <- function(x, w, probs = c(0.25, 0.5, 0.75), na.rm = TRUE, names = TRUE) {
   if(na.rm && anyNA(x)) {             # Removing missing values (only in x)
     cc = whichNA(x, invert = TRUE)    # The C code first calls radixorder(x), which places


### PR DESCRIPTION
Fixes a typo in the examples section of  (line 95): "Demonstaration" → "Demonstration".

### Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/fquantile.Rd | 1 | Documentation |

### Validation

-  — passes (no output = no errors)
- Change is purely documentation (no code changes)

### Stata Migration Relevance

This fix improves the readability of the  examples, which are useful for Stata migrants learning about weighted quantile computation in R. The  function is a fast alternative to R's  that supports sampling weights, similar to Stata's  command with weights.