### PR TITLE
docs: fix typo 'decomposion' -> 'decomposition' in qsu.Rd

### DIFF
--- a/man/qsu.Rd
+++ b/man/qsu.Rd
@@ -144,7 +144,7 @@ qsu(wlddev, pid = ~ iso3c, labels = TRUE)   # Adding between and within countrie
 x <- wlddev$PCGDP
 g <- wlddev$iso3c
 
-# This is the exact variance decomposion
+# This is the exact variance decomposition
 all.equal(fvar(x), fvar(B(x, g)) + fvar(W(x, g)))
 
 # What qsu does is calculate


### PR DESCRIPTION
Fix misspelling in the examples section where 'decomposion' should be 'decomposition'. This is in a comment explaining the variance decomposition formula for panel data.

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/qsu.Rd | 1 | Documentation |

## Validation

- `tools::checkRd('man/qsu.Rd')` — passes (no output = no errors)
- Change is purely documentation (no code changes)

## Stata Migration Relevance

This fix improves the readability of the `qsu` examples, which are directly inspired by Stata's `xtsummarize` command. The `qsu` function is a core tool for Stata migrants working with panel data in R.