### PR TITLE
docs: fix grammar 'can also computed' in collapse_and_plm.Rmd

### DIFF
--- a/vignettes/collapse_and_plm.Rmd
+++ b/vignettes/collapse_and_plm.Rmd
@@ -1240,7 +1240,7 @@ head(round(fsd(pwlddev$GINI, index(pwlddev, "iso3c")), 2), 20)
 
 ### 2.2 Summary Statistics for Panel Data
 
-Efficient summary statistics for panel data have long been implemented in other statistical softwares. The command `qsu`, shorthand for 'quick-summary', is a very efficient summary statistics command inspired by the *xtsummarize* command in the Stata statistical software. It computes a default set of 5 statistics (N, mean, sd, min and max) and can also computed higher moments (skewness and kurtosis) in a single pass through the data (using a numerically stable online algorithm generalized from Welford's Algorithm for variance computations). With panel data, `qsu` computes these statistics not just on the raw data, but also on the between-transformed and within-transformed data:
+Efficient summary statistics for panel data have long been implemented in other statistical softwares. The command `qsu`, shorthand for 'quick-summary', is a very efficient summary statistics command inspired by the *xtsummarize* command in the Stata statistical software. It computes a default set of 5 statistics (N, mean, sd, min and max) and can also compute higher moments (skewness and kurtosis) in a single pass through the data (using a numerically stable online algorithm generalized from Welford's Algorithm for variance computations). With panel data, `qsu` computes these statistics not just on the raw data, but also on the between-transformed and within-transformed data:
 
 
 ```r


### PR DESCRIPTION
## Summary

Fixed a grammar error in the  vignette where "can also computed" was used instead of "can also compute".

## Problem

Line 1243 of  stated:

> It computes a default set of 5 statistics (N, mean, sd, min and max) and can also computed higher moments (skewness and kurtosis)

"can also computed" is grammatically incorrect. The modal verb "can" requires the bare infinitive "compute", not the past participle "computed".

## Fix

Changed  to .

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| vignettes/collapse_and_plm.Rmd | 1 | Documentation |
| **Total** | **1** | |

## Validation

- Change is purely documentation (no code changes)
- The fix is in the section about , which is inspired by Stata's  command

## Stata Migration Relevance

This fix improves the readability of the  documentation in the panel data vignette, which is directly relevant for Stata migrants learning about panel data summary statistics in R. The  function is modeled after Stata's  and  commands.