### PR TITLE
docs: fix typos in GRP.Rd, BY.Rd, and collapse-package.Rd

### DIFF
--- a/man/BY.Rd
+++ b/man/BY.Rd
@@ -84,7 +84,7 @@ ml
 unlist2d(ml, idcols = "Variable", row.names = "Species")
 
 ## data.frame method
-BY(num_vars(iris), g, sum)             # Also returns a data.fram
+BY(num_vars(iris), g, sum)             # Also returns a data.frame
 BY(num_vars(iris), g, sum, return = 2) # Return as matrix.. also works for computations below
 head(BY(num_vars(iris), g, scale))
 BY(num_vars(iris), g, fquantile)

--- a/man/GRP.Rd
+++ b/man/GRP.Rd
@@ -109,7 +109,7 @@ fungroup(X, \dots)
 
   \item{return.order}{logical. If \code{sort = TRUE}, include the output from \code{\link{radixorder}} in the created GRP object. This brings performance improvements in \code{gsplit} (and thus also benefits grouped execution of base R functions). }
 
-  \item{method}{character. The algorithm to use for grouping: either \code{"radix"}, \code{"hash"} or \code{"auto"}. \code{"auto"} will chose \code{"radix"} when \code{sort = TRUE}, yielding ordered grouping via \code{\link{radixorder}}, and \code{"hash"}-based grouping in first-appearance order via \code{\link{group}} otherwise. It is possibly to put \code{method = "radix"} and \code{sort = FALSE}, which will group character data in first appearance order but sort numeric data (a good hybrid option). \code{method = "hash"} currently does not support any sorting, thus putting \code{sort = TRUE} will simply be ignored.}
+  \item{method}{character. The algorithm to use for grouping: either \code{"radix"}, \code{"hash"} or \code{"auto"}. \code{"auto"} will choose \code{"radix"} when \code{sort = TRUE}, yielding ordered grouping via \code{\link{radixorder}}, and \code{"hash"}-based grouping in first-appearance order via \code{\link{group}} otherwise. It is possible to put \code{method = "radix"} and \code{sort = FALSE}, which will group character data in first appearance order but sort numeric data (a good hybrid option). \code{method = "hash"} currently does not support any sorting, thus putting \code{sort = TRUE} will simply be ignored.}
 
   \item{group.sizes}{logical. \code{TRUE} tabulates factor levels using \code{\link{tabulate}} to create a vector of group sizes; \code{FALSE} leaves that slot empty when converting from factors.}
 

--- a/man/collapse-package.Rd
+++ b/man/collapse-package.Rd
@@ -253,7 +253,7 @@ microbenchmark(TRA(mtcars, sds, "/"), sweep(mtcars, 2, sds, "/")) # A remarkable
 sds <- fsd(mtcars, f2)
 head(TRA(mtcars, sds, "/", f2)) # Groupd scaling (if sd's not needed: fsd(mtcars, f2, TRA = "/"))
 
-# All functions above perserve the structure of matrices / data frames
+# All functions above preserve the structure of matrices / data frames
 # If conversions are required, use these efficient functions:
 mtcarsM <- qM(mtcars)                      # Matrix from data.frame
 head(qDF(mtcarsM))                         # data.frame from matrix columns
@@ -264,7 +264,7 @@ head(qDT(mtcars, "cars"))                  # Same use a data.frame
 ## Now let's get some real data and see how we can use this power for data manipulation
 head(wlddev) # World Bank World Development Data: 216 countries, 61 years, 5 series (columns 9-13)
 
-# Starting with some discriptive tools...
+# Starting with some descriptive tools...
 namlab(wlddev, class = TRUE)           # Show variable names, labels and classes
 fnobs(wlddev)                          # Observation count
 pwnobs(wlddev)                         # Pairwise observation count


### PR DESCRIPTION
## Summary

Fixed 4 documentation typos across 3 Rd files in the collapse package.

## Changes

### man/GRP.Rd (line 112)
- `will chose` → `will choose` (future tense requires base form of verb)
- `is possibly to put` → `is possible to put` (adjective needed, not adverb)

### man/BY.Rd (line 87)
- `data.fram` → `data.frame` (missing 'e' at end of word)

### man/collapse-package.Rd (lines 256, 267)
- `perserve` → `preserve` (misspelling)
- `discriptive` → `descriptive` (misspelling)

## Validation

- `tools::checkRd()` passes for all 3 modified files (no errors)
- Change is purely documentation (no code changes)

## Duplicate Check

- No existing open PRs address these typos in GRP.Rd, BY.Rd, or collapse-package.Rd
- PRs #850-#862 fix other Rd files but not these specific issues