### PR TITLE
docs: fix bare infinitive 'allow to' in fhdbetween_fhdwithin.Rd and recode-replace.Rd

### DIFF
--- a/man/fhdbetween_fhdwithin.Rd
+++ b/man/fhdbetween_fhdwithin.Rd
@@ -30,7 +30,7 @@ Higher-Dimensional Centering and Linear Prediction
 \description{
 \code{fhdbetween} is a generalization of \code{fbetween} to efficiently predict with multiple factors and linear models (i.e. predict with vectors/factors, matrices, or data frames/lists where the latter may contain multiple factor variables). Similarly, \code{fhdwithin} is a generalization of \code{fwithin} to center on multiple factors and partial-out linear models.
 
-The corresponding operators \code{HDB} and \code{HDW} additionally allow to predict / partial out full \code{lm()} formulas with interactions between variables.
+The corresponding operators \code{HDB} and \code{HDW} additionally allow predicting / partialing out full \code{lm()} formulas with interactions between variables.
 
 }
 \usage{

--- a/man/recode-replace.Rd
+++ b/man/recode-replace.Rd
@@ -97,7 +97,7 @@ replace_outliers(mtcars, 100, single.limit = "max") # Replace all value larger t
 replace_outliers(mtcars, 2)                         # Replace all values above or below 2 column-
                                                     # standard-deviations from the column-mean w. NA
 replace_outliers(fgroup_by(iris, Species), 2)       # Passing a grouped_df, pseries or pdata.frame
-                                                    # allows to remove outliers according to
+                                                    # allows removing outliers according to
                                                     # in-group standard-deviation. see ?fscale
 }
 % Add one or more standard keywords, see file 'KEYWORDS' in the


### PR DESCRIPTION
## Summary

Fixed two instances of the bare infinitive grammatical error "allow to" in collapse documentation.

## Problem

The verb "allow" requires a gerund (allow + -ing) or a noun phrase before "to" (allow + someone + to). Two Rd files contain the bare infinitive error "allow to":

1. **fhdbetween_fhdwithin.Rd line 33**: "allow to predict" — bare infinitive error
2. **recode-replace.Rd line 100**: "allows to remove" — bare infinitive error

## Fix

| File | Line | Before | After |
|------|------|--------|-------|
| man/fhdbetween_fhdwithin.Rd | 33 | "allow to predict" | "allow predicting" |
| man/recode-replace.Rd | 100 | "allows to remove" | "allows removing" |

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/fhdbetween_fhdwithin.Rd | 1 | Documentation |
| man/recode-replace.Rd | 1 | Documentation |
| **Total** | **2** | |

## Validation

- `tools::checkRd('man/fhdbetween_fhdwithin.Rd')` — passes (no output = no errors)
- `tools::checkRd('man/recode-replace.Rd')` — passes (no output = no errors)
- Change is purely documentation (no code changes)

## Duplicate Check

- No existing branch or PR addresses bare infinitive in fhdbetween_fhdwithin.Rd or recode-replace.Rd
- No other PRs touch these lines

## Stata Migration Relevance

The `fhdbetween/fhdwithin` functions are powerful tools for high-dimensional linear prediction problems involving large factors and datasets. They are particularly useful for Stata users migrating to R, as they provide an efficient alternative to Stata's `areg` and `xtreg` commands for fixed effects models. The `HDB` and `HDW` operators add formula support similar to Stata's factor variable notation. Clear documentation helps Stata users understand these advanced features.

The `recode-replace.Rd` documentation describes functions for recoding and replacing values, which is a common data cleaning operation for Stata users. Stata's `recode` and `replace` commands are frequently used, and clear documentation of the collapse equivalents helps Stata users transition to R.