### PR TITLE
Fix fmatch() matching logical NA to non-logical table values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # collapse 2.1.7
 
+* Fixed a bug in `fmatch()` (and thus `%in%`/`%iin%` and joins) where a logical `NA` in `x` could spuriously match a non-logical integer value in `table` (e.g., `2L`), instead of yielding `NA` as in `base::match()`. Thanks @LJ-Jenkins for reporting (#870).
+
 * Fixed a bug in `fslice()` (grouped, `n = 1`, `with.ties = FALSE`) that caused R to crash with a fatal error when a group had only missing values in `order.by`. Thanks @chihyunkim for reporting (#867).
 
 * The *collapse* article is now published in the Journal of Statistical Software: https://doi.org/10.18637/jss.v116.i01. This article is now the primary citation for academic use of *collapse*. It is also a great reference to quickly and thoroughly understand the package. `citation("collapse")` was also updated in this regard. The APA-style citation is:

--- a/src/match.c
+++ b/src/match.c
@@ -152,7 +152,8 @@ SEXP match_single(SEXP x, SEXP table, SEXP nomatch) {
     } else goto bigint;
     anyNA = !(inherits(x, "na.included") && inherits(table, "na.included"));
   } else if (tx == LGLSXP) {
-    M = 3;
+    if(TYPEOF(table) == LGLSXP) M = 3;
+    else { tx = INTSXP; goto bigint; } // table is not logical: cannot assume values are in {0, 1, NA}, need generic hashing
   } else error("Type %s is not supported.", type2char(tx));
 
   int *restrict h = (int*)R_Calloc(M, int); // Table to save the hash values, table has size M

--- a/tests/testthat/test-fmatch.R
+++ b/tests/testthat/test-fmatch.R
@@ -178,3 +178,26 @@ test_that("fmatch works with logical data", {
   expect_equal(fmatch(FALSE, x), 2L)
 })
 
+test_that("fmatch does not match logical NA in x to non-logical values in table (#870)", {
+  x <- c(FALSE, TRUE, NA)
+  table <- c(0L, 1L, 2L)
+  expect_identical(fmatch(x, table), match(x, table))
+  expect_identical(fmatch(x, table, nomatch = 0L), match(x, table, nomatch = 0L))
+  expect_identical(NA %iin% table, NA_integer_)
+
+  # Reverse direction (already worked before the fix)
+  expect_identical(fmatch(table, x), match(table, x))
+
+  # Larger table values should not collide with the NA sentinel bucket
+  table2 <- c(0L, 1L, 2L, 3L, 4L, 5L)
+  x2 <- c(TRUE, FALSE, NA)
+  expect_identical(fmatch(x2, table2), match(x2, table2))
+
+  # Genuine logical x and table still work (fast path retained)
+  expect_identical(fmatch(c(TRUE, FALSE, NA), c(FALSE, TRUE, NA)),
+                    match(c(TRUE, FALSE, NA), c(FALSE, TRUE, NA)))
+
+  # Double table
+  expect_identical(fmatch(x, c(0, 1, 2)), match(x, c(0, 1, 2)))
+})
+


### PR DESCRIPTION
## Summary
* Fixes a bug where `fmatch()` (and thus `%in%`/`%iin%` and joins) matched a logical `NA` in `x` to a non-logical integer value in `table` (e.g., `2L`) instead of returning `NA` like `base::match()`.
* Root cause: in `src/match.c::match_single()`, a logical `x` always took a specialized 3-bucket hash path (reserving one bucket for NA) regardless of whether `table` was actually logical, causing collisions with real table values.
* Fix: only use the specialized path when `table` is also logical; otherwise fall back to the generic, collision-safe integer hashing path.

Closes #870.

## Test plan
- [x] Added regression tests in `tests/testthat/test-fmatch.R` comparing against `base::match()`
- [ ] CI/R CMD check should be run to confirm (could not run R locally in this sandbox)

Generated with [Claude Code](https://claude.ai/code)